### PR TITLE
Python 2 Compatibility

### DIFF
--- a/fsm.py
+++ b/fsm.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (C) 2012 by Sam Hughes
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -559,11 +560,11 @@ if __name__ == "__main__":
 
 	# Buggggs.
 	abstar = fsm(
-		{'a', None, 'b'},
-		{0, 1},
-		0,
-		{0},
-		{
+		alphabet = {'a', None, 'b'},
+		states	 = {0, 1},
+		initial	 = 0,
+		finals	 = {0},
+		map	 = {
 			0: {'a': 0, None: 1, 'b': 0},
 			1: {'a': 1, None: 1, 'b': 1}
 		}
@@ -571,11 +572,11 @@ if __name__ == "__main__":
 	assert str(abstar.lego()) == "[ab]*"
 
 	adotb = fsm(
-		{'a', None, 'b'},
-		{0, 1, 2, 3, 4},
-		0,
-		{4},
-		{
+		alphabet = {'a', None, 'b'},
+		states	 = {0, 1, 2, 3, 4},
+		initial	 = 0,
+		finals	 = {4},
+		map	 = {
 			0: {'a': 2, None: 1, 'b': 1},
 			1: {'a': 1, None: 1, 'b': 1},
 			2: {'a': 3, None: 3, 'b': 3},
@@ -658,7 +659,7 @@ if __name__ == "__main__":
 		states   = {0, 1, "ob"},
 		initial  = 0,
 		finals   = {1},
-		map = {
+		map      = {
 			0    : {"a" : "ob", "b" : 1   },
 			1    : {"a" : "ob", "b" : "ob"},
 			"ob" : {"a" : "ob", "b" : "ob"},
@@ -782,9 +783,9 @@ if __name__ == "__main__":
 	# FSM accepts no strings but has 3 states, needs only 1
 	asdf = fsm(
 		alphabet = {None},
-		states = {0, 1, 2},
-		initial = 0,
-		finals = {1},
+		states   = {0, 1, 2},
+		initial  = 0,
+		finals   = {1},
 		map = {
 			0 : {None : 2},
 			1 : {None : 2},
@@ -797,9 +798,9 @@ if __name__ == "__main__":
 	# FSM reversal
 	abc = fsm(
 		alphabet = {"a", "b", "c"},
-		states = {0, 1, 2, 3, None},
-		initial = 0,
-		finals = {3},
+		states   = {0, 1, 2, 3, None},
+		initial  = 0,
+		finals   = {3},
 		map = {
 			0    : {"a" : 1   , "b" : None, "c" : None},
 			1    : {"a" : None, "b" : 2   , "c" : None},

--- a/main.py
+++ b/main.py
@@ -8,11 +8,22 @@ from lego import parse
 regexes = sys.argv[1:]
 
 if len(regexes) < 2:
-	print("Please supply several regexes to compute their intersection.")
+	print("Please supply several regexes to compute their intersection, union and concatenation.")
 	print("E.g. \"19.*\" \"\\d{4}-\\d{2}-\\d{2}\"")
 
 else:
 	p = parse(regexes[0])
 	for regex in regexes[1:]:
 		p &= parse(regex)
-	print(p)
+	print("Intersection:  %s" % ( p ))
+
+	p = parse(regexes[0])
+	for regex in regexes[1:]:
+		p |= parse(regex)
+	print("Union:         %s" % ( p ))
+
+	p = parse(regexes[0])
+	for regex in regexes[1:]:
+		p += parse(regex)
+	print("Concatenation: %s" % ( p ))
+


### PR DESCRIPTION
I've added Python 2 compatibility, with minimal impact to the existing code.   All unit tests pass in Python 2.7 and Python 3.3.  The two main issues were the use of the 'nonlocal' keyword in a closure (it was quite easily removed without losing too much beauty), and the lack of explicit != operators (the **eq** magic method wasn't being automatically used to implement !=).

o Specify file encoding is utf-8
o Consistenly use tab indentation
o Added != (**ne**) support in terms of == (**eq**) to all classes
o Simplify charclass.escape to not use Python3-only nonlocal keyword
o Add union and concatenation to the main.py demo
