### PR TITLE
Implemented handling of expressions matching no input

### DIFF
--- a/fsm.py
+++ b/fsm.py
@@ -224,8 +224,14 @@ class fsm:
 
 	def __mul__(self, multiplier):
 		'''
-			Given an FSM and a multiplier, return the multiplied FSM.
+			Given an FSM and a multiplier, return the multiplied
+			FSM.  Handles None (accepts nothing), 0 (accepts the
+			empty string), and +'ve finite values (accepts a
+			sequence of the underlying FSM)
 		'''
+		if multiplier is None:
+			return null(self.alphabet)
+
 		assert multiplier >= 0
 
 		if multiplier == 0:
@@ -399,7 +405,7 @@ class fsm:
 		'''
 		from lego import nothing, charclass, emptystring, star, otherchars
 
-		outside = 0
+		outside = len(self.states)
 		while outside in self.states:
 			outside += 1
 
@@ -711,8 +717,14 @@ if __name__ == "__main__":
 	assert not twoA.accepts("aaa")
 
 	zeroA = a * 0
+	assert str(zeroA.lego()) == ""
 	assert zeroA.accepts("")
 	assert not zeroA.accepts("a")
+
+	neverA = a * None
+	assert str(neverA.lego()) == "[]"
+	assert not neverA.accepts("")
+	assert not neverA.accepts("a")
 
 	# intersection simple test
 	intAB = a & b

--- a/main.py
+++ b/main.py
@@ -2,28 +2,118 @@
 
 # http://qntm.org/greenery
 
+from __future__ import print_function
+
 import sys
 from lego import parse
 
-regexes = sys.argv[1:]
+regexes = []
+verbose = 0
+interactive = 0
+errors = 0
+helptext = 0
+timing = 0
+tests = None
 
-if len(regexes) < 2:
+# Extract options:
+#    --verbose,	    -v[vv]
+#    --interactive, -i
+#    --help,        -h
+#    --time,        -t
+#    -- "test string" ...
+
+for i in range(1,len(sys.argv)):
+	arg = sys.argv[i]
+	# Long-form options "--word"?
+	if arg == "--verbose":
+		arg="-v"
+	elif arg == "--interactive":
+		arg="-i"
+	elif arg == "--help":
+		arg="-h"
+	elif arg == "--time":
+		arg="-t"
+	elif arg == "--":
+                #  -- ...: Remaining args are test vectors
+		tests = sys.argv[i+1:]
+		break
+	elif arg.startswith("--"):
+		print("Unrecognized long option: %s" % ( arg ))
+		exit(1)
+	elif not arg.startswith("-"):
+		regexes.append(arg)
+		continue
+	# Short-form options "-x[...]"
+	for opt in arg[1:]:
+		if opt == "h":
+			helptext += 1
+		elif opt == "v":
+			verbose += 1
+		elif opt == "i":
+			interactive += 1
+		elif opt == "t":
+			timing += 1
+		else:
+			print("Invalid option: -%s" % ( opt ))
+			errors += 1
+if len(regexes) < 1:
 	print("Please supply several regexes to compute their intersection, union and concatenation.")
 	print("E.g. \"19.*\" \"\\d{4}-\\d{2}-\\d{2}\"")
+	errors += 1
 
-else:
-	p = parse(regexes[0])
+if errors or helptext:
+	print("%s [--verbose|-v] [--help|-h] [--interactive|-i] [--time|-t] regex [...] [-- test ...]" % ( sys.argv[0] ))
+
+if errors:
+	exit(1)
+
+def build( regexes ):
+	d = dict()
+
+	i = parse(regexes[0])
 	for regex in regexes[1:]:
-		p &= parse(regex)
-	print("Intersection:  %s" % ( p ))
+		i &= parse(regex)
+	d["Intersection"] = (i,i.fsm())
 
-	p = parse(regexes[0])
+	u = parse(regexes[0])
 	for regex in regexes[1:]:
-		p |= parse(regex)
-	print("Union:         %s" % ( p ))
-
-	p = parse(regexes[0])
+		u |= parse(regex)
+	ufsm = d["Union"] = (u,u.fsm())
+	
+	c = parse(regexes[0])
 	for regex in regexes[1:]:
-		p += parse(regex)
-	print("Concatenation: %s" % ( p ))
+		c += parse(regex)
+	cfsm = d["Concatenation"] = (c,c.fsm())
 
+	return d
+
+if timing:
+	import timeit
+	t = timeit.Timer('build(regexes)',setup='from __main__ import build, regexes')
+	rep, num = 3, 5
+	print("%.3f ms/loop avg" % (1000*min(t.repeat(rep,num))/num))
+
+d = build(regexes)
+for k,rm in d.items():
+	r,m = rm
+	print( "%-20s: %s" % ( k, r ))
+	if verbose:
+		print( str( m ))
+
+def input_lines( prompt="--> "):
+	line = input(prompt)
+	while line:
+		yield line
+		line = input(prompt)
+
+if interactive or tests:
+	for line in tests if tests else input_lines():
+		print("Testing w/: %r" % line )
+		for k,rm in d.items():
+			r,m = rm
+			try:
+				result = m.accepts(line)
+			except Exception as e:
+				result = repr( e )
+			print("%-20s: %-20s: %s" % ( k, r, result))
+	


### PR DESCRIPTION
Previously, attempting to take the intersection of regular expressions with
non-overlapping multipliers (eg "aa" & "aaaa") would raise an Exception, instead
of producing a no match regular expression "[]".  These (and other no-match)
expressions are now handled.

o Added a lego.multiplier representing 'never', by making the
  multiplier.min/.max both 'inf' (bound(None)), a previously unused
  configuration.  This turns out to require little additional logic, and
  actually cleans up some code.
o Handle multiplying an fsm by None to produce null (no match) fsm
o Optimize search for unused state number slightly to ~O(1) vs. O(n)
o Simplified <bound> - <bound>, while adding handling for never
o Allow representation of {} (never) and {0} (empty string) multipliers,
  since they are always reduced
o Intersection of non-overlapping multipliers now produces new 'never'
  multiplier, instead of producing invalid (inverted) multiplier Exception
o Prevent elimination of {}, {0} on lego string rendering; should virtually
  never occur anyway, due to elimination by reduce()
o Moved bound/multiplier testing to start of unit tests, due to their
  foundational nature.
o Added some empty/no-match unit tests
o Expand main.py to allow playing around with more expression variants,
  including timing, and an interactive mode for testing input against union,
  intersection and concatenation of supplied expression(s).
o Moved the lego.py multiplier tests to original order to minimize merge
o Restored restriction on representing zero/never multipliers in regexes
o Corrected processing of test input vectors in main.py example code
