### PR TITLE
fix concatenation of anything_else

### DIFF
--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -210,8 +210,11 @@ class fsm:
 			next = set()
 			for (i, substate) in current:
 				fsm = fsms[i]
-				if substate in fsm.map and symbol in fsm.map[substate]:
-					next.update(connect_all(i, fsm.map[substate][symbol]))
+				if substate in fsm.map:
+					if symbol in fsm.map[substate]:
+						next.update(connect_all(i, fsm.map[substate][symbol]))
+					elif  anything_else in fsm.map[substate] and symbol not in fsm.alphabet:
+						next.update(connect_all(i,fsm.map[substate][anything_else]))
 			if len(next) == 0:
 				raise OblivionError
 			return frozenset(next)

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -708,3 +708,20 @@ def test_bug_36():
 	assert etc2.accepts(["s"])
 	assert both.alphabet == {anything_else, "s"}
 	assert both.accepts(["s"])
+
+def test_add_anything_else():
+	fsm1=fsm( # [^a]
+		alphabet={"a",anything_else},
+		states={0,1},
+		initial=0,
+		finals={1},
+		map={0:{anything_else:1}}
+	)
+	fsm2=fsm( # [^b]
+		alphabet={"b",anything_else},
+		states={0,1},
+		initial=0,
+		finals={1},
+		map={0:{anything_else:1}}
+	)
+	assert (fsm1+fsm2).accepts("ba")


### PR DESCRIPTION
When concatenating fsms with differing alphabets, symbols from the others' alphabets do not map as if they were anything_else.

For example:
```
# [^a]
fsm1=fsm(
  alphabet={"a",anything_else},
  states={0,1},
  initial=0,
  finals={1},
  map={0:{anything_else:1}}
# .
fsm2=fsm(
  alphabet={anything_else},
  states={0,1},
  initial=0,
  finals={1},
  map={0:{anything_else:1}}
  )
# [^a].
assert (fsm1+fsm2).accepts("ba") # Fails
```
Looking at the concatenated result,
```
>>> print(fsm1+fsm2)
 name final? a anything_else 
------------------------------
* 0    False    1             
  1    False    2             
  2    True                   
```
We see that "a" which is not in fsm2's alphabet does not get treated as if it were anything_else as it should.
To fix this, we check to see if the character is not in the alphabet and create the same transition as anything_else (if anything_else has such a transition).

This however doesn't seem to be an issue when concatenated through the lego module though.
Edit: lego merges the alphabet before converting to fsm.
```
>>> l1=lego.parse("[^a]")
>>> l2=lego.parse(".")
>>> print(l1.to_fsm()+l2.to_fsm())
  name final? a anything_else 
------------------------------
* 0    False    1             
  1    False    2             
  2    True                  
>>> print((l1+l2).to_fsm())
  name final? a anything_else 
------------------------------
* 0    False    1             
  1    False  2 2             
  2    True                   
```