### PR TITLE
Use frozen dataclasses and type annotations

### DIFF
--- a/greenery/lego.py
+++ b/greenery/lego.py
@@ -60,14 +60,14 @@ def call_fsm(method):
         return from_fsm(fsm_method(*[lego.to_fsm(alphabet) for lego in legos]))
     return new_method
 
-def parse(string):
+def parse(string: str):
     '''
         Parse a full string and return a lego piece. Fail if the whole string
         wasn't parsed
     '''
     return pattern.parse(string)
 
-def from_fsm(f):
+def from_fsm(f: fsm.fsm):
     '''
         Turn the supplied finite state machine into a `lego` object. This is
         accomplished using the Brzozowski algebraic method.
@@ -170,7 +170,7 @@ def select_static(string, i, *statics):
             return j, st
     raise nomatch
 
-def read_until(string, i, stop_char):
+def read_until(string: str, i: int, stop_char: str) -> tuple[int, str]:
     start = i
     while True:
         if i >= len(string):
@@ -194,7 +194,7 @@ class lego:
         '''
         raise Exception("This object is immutable.")
 
-    def to_fsm(self, alphabet):
+    def to_fsm(self, alphabet=None):
         '''
             Return the present lego piece in the form of a finite state machine,
             as imported from the fsm module.
@@ -222,7 +222,7 @@ class lego:
         raise NotImplementedError()
 
     @classmethod
-    def match(cls, string, i = 0):
+    def match(cls, string: str, i = 0):
         '''
             Start at index i in the supplied string and try to match one of the
             present class. Elementary recursive descent parsing with very little
@@ -232,7 +232,7 @@ class lego:
         raise NotImplementedError()
 
     @classmethod
-    def parse(cls, string):
+    def parse(cls, string: str):
         '''
             Parse the entire supplied string as an instance of the present class.
             Mainly for internal use in unit tests because it drops through to match()
@@ -874,7 +874,7 @@ class bound:
         return str(self.v)
 
     @classmethod
-    def match(cls, string, i = 0):
+    def match(cls, string: str, i = 0):
         def matchAnyOf(string, i, collection):
             for char in collection:
                 try:
@@ -1811,7 +1811,7 @@ class pattern(lego):
         return self
 
     @classmethod
-    def match(cls, string, i = 0):
+    def match(cls, string: str, i = 0):
         concs = list()
 
         # first one

--- a/greenery/lego_test.py
+++ b/greenery/lego_test.py
@@ -766,7 +766,7 @@ def test_charclass_intersection():
 
 def test_empty():
     assert nothing.empty()
-    assert charclass().empty()
+    assert charclass("").empty()
     assert not dot.empty()
     assert not mult.parse("a{0}").empty()
     assert mult.parse("[]").empty()
@@ -1076,7 +1076,7 @@ def test_two_two_bug():
 # Test intersection (&)
 
 def test_mult_intersection():
-    assert mult.parse("a") & mult.parse("b?") == charclass()
+    assert mult.parse("a") & mult.parse("b?") == charclass("")
     assert mult.parse("a") & mult.parse("b?") == nothing
     assert mult.parse("a") & mult.parse("a?") == charclass.parse("a")
     assert mult.parse("a{2}") & mult.parse("a{2,}") == mult.parse("a{2}")
@@ -1177,7 +1177,7 @@ def test_pattern_reduce_basic():
     assert pattern.parse("a").reduce() == charclass.parse("a")
 
 def test_empty_pattern_reduction():
-    assert pattern().reduce() == charclass()
+    assert pattern().reduce() == charclass("")
 
 def test_empty_mult_suppression():
     assert conc.parse("[]0\\d").reduce() == charclass.parse("[]")


### PR DESCRIPTION
The main benefit of using the more established convention `@dataclass(frozen=True)` and `object.__setattr__(self, "attribute", set(self.attibute))` instead of the current `self.__dict__["attribute" ] = attribute` is it allows for better static inspection by IDEs like PyCharm and VSCode.

This only took me an hour of work, so I'm fine you reject this MR because if this type of code feels unnatural to you and/or if you don't use an IDE.

I'm also happy to discuss this MR further if you'd like more explanation behind this MR.