### PR TITLE
added a reduction rule for concs of mults

### DIFF
--- a/greenery/lego.py
+++ b/greenery/lego.py
@@ -1465,6 +1465,26 @@ class conc(lego):
                 new = self.mults[:i] + self.mults[i+1:]
                 return conc(*new)
 
+        # If R's language is a subset of S's, then R{a,b}S{c,} reduces to R{a}S{c,}.
+        # Conversely, S{c,}R{a,b} reduces to S{c,}R{a}.
+        if len(self.mults) > 1:
+            for i in range(len(self.mults) - 1):
+                for (R_first,R,S) in (
+                  (True, self.mults[i], self.mults[i+1]), 
+                  (False, self.mults[i+1],self.mults[i])
+                  ):
+                    if R.multiplicand.intersection(S.multiplicand).equivalent(R.multiplicand) \
+                      and (R.multiplier.min != R.multiplier.max) \
+                      and (S.multiplier.max == bound(None)):
+                        trimmed_R = mult(
+                            R.multiplicand,
+                            multiplier(R.multiplier.min, R.multiplier.min)
+                            )
+                        new = self.mults[:i] + \
+                          ((S, trimmed_R,), (trimmed_R, S,))[R_first] + self.mults[i + 2:]
+                        return conc(*new)
+                
+
         # multiple mults with identical multiplicands in a row?
         # squish those together
         # e.g. ab?b?c -> ab{0,2}c

--- a/greenery/lego_test.py
+++ b/greenery/lego_test.py
@@ -1038,6 +1038,10 @@ def test_reduce_concatenations():
     assert parse("za{2,3}(a{2}b|a+c)").reduce() == conc.parse("za{3,4}(ab|a*c)")
     assert parse("(ba{2}|ca+)a{2,3}z").reduce() == conc.parse("(ba|ca*)a{3,4}z")
     assert parse("(a|bc)(a|bc)").reduce() == mult.parse("(a|bc){2}")
+    assert parse("a+[ab]+").reduce() == conc.parse("a[ab]+")
+    assert parse("a{3,8}[ab]+").reduce() == conc.parse("a{3}[ab]+")
+    assert parse("[ab]+b+").reduce() == conc.parse("[ab]+b")
+    assert parse("[ab]+a{3,8}").reduce() == conc.parse("[ab]+a{3}")
 
 ################################################################################
 # Multiplication tests


### PR DESCRIPTION
Found an additional simplification rule during a course project! I _think_ this is as specific as it can get:

If R's language is a subset of S's, then R{a,b}S{c,inf} reduces to R{a}S{c,inf} and S{c,inf}R{a,b} reduces to S{c,inf}R{a}.
For instance, \d+\w+ reduces to \d\w+, and [ab]+a? reduces to [ab]+.

Adding the rule I put in lego.py makes the four tests I added in lego_test pass and does not make any other tests fail.

[also, huge fan of There Is No Antimemetics Division -- I have a copy!]