### PR TITLE
Simplify `mult` collapsing behaviour

### DIFF
--- a/greenery/lego_test.py
+++ b/greenery/lego_test.py
@@ -1042,6 +1042,8 @@ def test_reduce_concatenations():
     assert parse("a{3,8}[ab]+").reduce() == conc.parse("a{3}[ab]+")
     assert parse("[ab]+b+").reduce() == conc.parse("[ab]+b")
     assert parse("[ab]+a{3,8}").reduce() == conc.parse("[ab]+a{3}")
+    assert parse("\\d+\\w+").reduce() == conc.parse("\\d\\w+")
+    assert parse("[ab]+a?").reduce() == mult.parse("[ab]+")
 
 ################################################################################
 # Multiplication tests


### PR DESCRIPTION
Follows #62.

* Add a few more unit tests, including tests for the cases specifically suggested in that PR's leading comment.
* Instead of looping over all the `mult`s in a `conc` twice (once for the R >= S and R <= S tests, once for the R = S test), do it once, binding the mults to `r` and `s` at the start of the loop body.
* Split loop which handles R >= S and R <= S up into two distinct loops. This is a completely subjective change, but in my opinion this is a more readable and it makes some other simplifications possible.
* Move the test for when R = S to be *above* the newly-added test for when R >= S or R <= S - otherwise we end up reducing this `conc` twice for no real reason.
* Move the expensive test for R >= S or R <= S to be before the relatively cheap bounds tests.
* Add an example or two in comments.