### PR TITLE
fix: rxelems.isdisjoint: incorrect use of `@call_fsm` on boolean method

### DIFF
--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -688,13 +688,12 @@ class Pattern:
     def derive(self, string):
         return from_fsm(self.to_fsm().derive(string))
 
-    @call_fsm
     def isdisjoint(self, other):
         '''
             Treat `self` and `other` as sets of strings and see if they are
             disjoint
         '''
-        pass
+        return self.to_fsm().isdisjoint(other.to_fsm())
 
     def matches(self, string):
         return self.to_fsm().accepts(string)

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -937,6 +937,14 @@ def test_bug_36_2():
     assert not etc2.isdisjoint(etc1)
 
 
+def test_isdisjoint():
+    xyzzy = parse("xyz(zy)?")
+    xyz = parse("xyz")
+    blippy = parse("blippy")
+    assert xyzzy.isdisjoint(blippy)
+    assert not xyzzy.isdisjoint(xyz)
+
+
 def test_bug_slow():
     # issue #43
     import time


### PR DESCRIPTION
The `@call_fsm` decorator only works for methods which return a FSM, however this method returns a boolean.

This is a bugfix that existed in v3 and has been rebased because it still exists in V4. It includes a test which exercises the previously unexercised method.