### PR TITLE
fix incorrect combination of open charclass predicates

### DIFF
--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -95,16 +95,16 @@ def match_internal_char(string, i):
 
 def match_class_interior_1(string, i):
     # Attempt 1: shorthand e.g. "\w"
-    for frozenset, cc_shorthand in Charclass.shorthand.items():
+    for chars, cc_shorthand in Charclass.shorthand.items():
         try:
-            return frozenset, False, static(string, i, cc_shorthand)
+            return chars, False, static(string, i, cc_shorthand)
         except NoMatch:
             pass
 
     # Attempt 1B: shorthand e.g. "\W"
-    for frozenset, cc_shorthand in Charclass.negated_shorthand.items():
+    for chars, cc_shorthand in Charclass.negated_shorthand.items():
         try:
-            return frozenset, True, static(string, i, cc_shorthand)
+            return chars, True, static(string, i, cc_shorthand)
         except NoMatch:
             pass
 

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -121,20 +121,18 @@ def match_class_interior_1(string, i):
         if firstIndex >= lastIndex:
             raise NoMatch(f"Range '{first}' to '{last}' not allowed")
 
-        chars = set([
-            chr(i) for i in range(firstIndex, lastIndex + 1)
-        ])
+        chars = frozenset(chr(i) for i in range(firstIndex, lastIndex + 1))
         return chars, False, k
     except NoMatch:
         pass
 
     # Attempt 3: just a character on its own
     (char, j) = match_internal_char(string, i)
-    return set(char), False, j
+    return frozenset(char), False, j
 
 
 def match_class_interior(string, i):
-    internals = set()
+    internals = frozenset()
     internals_negated = False
     try:
         while True:

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -132,26 +132,27 @@ def match_class_interior_1(string, i):
 
 
 def match_class_interior(string, i):
-    internals = frozenset()
-    internals_negated = False
+    chars = frozenset()
+    has_negated = False
     try:
         while True:
+            # Match an internal character, range, or other charclass predicate.
             internal, internal_negated, i = match_class_interior_1(string, i)
             if internal_negated:
-                if internals_negated:
+                if has_negated:
                     # E.g. [a1\D\W]
-                    internals |= internal
+                    chars |= internal
                 else:
-                    internals_negated = True
-                    internals = internal - internals
+                    has_negated = True
+                    chars = internal - chars
             else:
-                if internals_negated:
-                    internals = internals - internal
+                if has_negated:
+                    chars = chars - internal
                 else:
-                    internals |= internal
+                    chars |= internal
     except NoMatch:
         pass
-    return internals, internals_negated, i
+    return chars, has_negated, i
 
 
 def match_charclass(string: str, i):

--- a/greenery/parse_test.py
+++ b/greenery/parse_test.py
@@ -41,10 +41,10 @@ def test_negatives_inside_charclasses():
     assert match_charclass("[\\D1a]", 0) == (~Charclass("023456789"), 6)
     assert match_charclass("[\\D\\d]", 0) == (DOT, 6)
     assert match_charclass("[\\D\\D]", 0) == (~DIGIT, 6)
-    assert match_charclass("[\\S\\D]", 0) == \
-        (~Charclass("\t\n\v\f\r 0123456789"), 6)
-    assert match_charclass("[\\S \\D]", 0) == \
-        (~Charclass("\t\n\v\f\r0123456789"), 7)
+
+    # "Either non-whitespace or a non-digit" matches _anything_.
+    assert match_charclass("[\\S\\D]", 0) == (DOT, 6)
+    assert match_charclass("[\\S \\D]", 0) == (DOT, 7)
 
 
 def test_negated_negatives_inside_charclasses():
@@ -58,10 +58,10 @@ def test_negated_negatives_inside_charclasses():
     assert match_charclass("[^\\D1a]", 0) == (Charclass("023456789"), 7)
     assert match_charclass("[^\\D\\d]", 0) == (NULLCHARCLASS, 7)
     assert match_charclass("[^\\D\\D]", 0) == (DIGIT, 7)
-    assert match_charclass("[^\\S\\D]", 0) == \
-        (Charclass("\t\n\v\f\r 0123456789"), 7)
-    assert match_charclass("[^\\S \\D]", 0) == \
-        (Charclass("\t\n\v\f\r0123456789"), 8)
+
+    # "Anything but non-whitespace and non-digit" matches _nothing_.
+    assert match_charclass("[^\\S\\D]", 0) == (NULLCHARCLASS, 7)
+    assert match_charclass("[^\\S \\D]", 0) == (NULLCHARCLASS, 8)
 
 
 def test_mult_matching():


### PR DESCRIPTION
Open/negated charclass predicates like `\W` and `\S` were combined incorrectly.

They were interpreted as as `not (whitespace or digits)` but their correct interpretation is `(not whitespace) or (not digits)`.

This fixes the misinterpretation and the test. It includes a couple minor nits that made it easier to rebase the fix.

Although I didn't include as a test in this PR because there are plausible reasons that the test suite doesn't already do this, I verified the behaviour against the built-in `re` module with:

```py
import re
from greenery import parse


def test_expr(expr, value):
    pat = parse(expr)
    rx = re.compile(expr)
    assert bool(rx.match(value)) == bool(pat.matches(value))


for expr in (r"\S\D", r"1\D", r"1\D\S"):
    for negation in (True, False):
        for value in "12x ":
            test_expr(f'[{"^" if negation else ""}{expr}]', value)
```

I also confirmed consistency with some manual tinkering in javascript.