### PR TITLE
test/style: use `pytest.raises` vs `except: …`/`assert False`

### DIFF
--- a/greenery/conc_test.py
+++ b/greenery/conc_test.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import pytest
+
 from .bound import Bound
 from .multiplier import Multiplier, ZERO, QM, ONE, STAR, PLUS
 from .charclass import Charclass
@@ -60,13 +62,8 @@ def test_conc_dock():
     assert Conc(a, b, x, yplus, z).behead(Conc(a, b, x, yplus)) == Conc(z)
     assert Conc(a).dock(Conc()) == Conc(a)
 
-    try:
+    with pytest.raises(Exception, match="Can't subtract"):
         Conc(x2, yplus, z).behead(Conc(x, yplus))
-        assert False
-    except AssertionError:
-        assert False
-    except Exception:
-        pass
 
 
 def test_mult_reduction_easy():

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -417,7 +417,7 @@ def test_binary_3():
 
 def test_invalid_fsms():
     # initial state 1 is not a state
-    try:
+    with pytest.raises(Exception, match="Initial state"):
         Fsm(
             alphabet={},
             states={},
@@ -425,14 +425,9 @@ def test_invalid_fsms():
             finals=set(),
             map={}
         )
-        assert False
-    except AssertionError:
-        assert False
-    except Exception:
-        pass
 
     # final state 2 not a state
-    try:
+    with pytest.raises(Exception, match="Final states"):
         Fsm(
             alphabet={},
             states={1},
@@ -440,14 +435,9 @@ def test_invalid_fsms():
             finals={2},
             map={}
         )
-        assert False
-    except AssertionError:
-        assert False
-    except Exception:
-        pass
 
     # invalid transition for state 1, symbol "a"
-    try:
+    with pytest.raises(Exception, match="Transition.+leads to.+not a state"):
         Fsm(
             alphabet={"a"},
             states={1},
@@ -457,21 +447,11 @@ def test_invalid_fsms():
                 1: {"a": 2}
             }
         )
-        assert False
-    except AssertionError:
-        assert False
-    except Exception:
-        pass
 
 
 def test_bad_multiplier(a):
-    try:
+    with pytest.raises(Exception, match="Can't multiply"):
         a * -1
-        assert False
-    except AssertionError:
-        assert False
-    except Exception:
-        pass
 
 
 def test_anything_else_acceptance():
@@ -627,11 +607,9 @@ def test_new_set_methods(a, b):
     # But do they work?
     assert len(a) == 1
     assert len((a | b) * 4) == 16
-    try:
+
+    with pytest.raises(OverflowError):
         len(a.star())
-        assert False
-    except OverflowError:
-        pass
 
     # "in"
     assert "a" in a
@@ -720,11 +698,10 @@ def test_derive(a, b):
     # Just some basic tests because this is mainly a regex thing.
     assert a.derive("a") == epsilon({"a", "b"})
     assert a.derive("b") == null({"a", "b"})
-    try:
+
+    with pytest.raises(KeyError):
         a.derive("c")
-        assert False
-    except KeyError:
-        assert True
+
     assert (a * 3).derive("a") == a * 2
     assert (a.star() - epsilon({"a", "b"})).derive("a") == a.star()
 

--- a/greenery/multiplier_test.py
+++ b/greenery/multiplier_test.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import pytest
+
 from .bound import Bound, INF
 from .multiplier import Multiplier, ZERO, ONE, QM, STAR, PLUS
 
@@ -108,10 +110,6 @@ def test_multiplier_union():
             Bound(4)
         )
     )
-    try:
+
+    with pytest.raises(Exception, match="Can't compute the union"):
         ZERO | Multiplier(Bound(7), Bound(8))
-        assert False
-    except AssertionError:
-        assert False
-    except Exception:
-        pass

--- a/greenery/parse_test.py
+++ b/greenery/parse_test.py
@@ -5,6 +5,8 @@ if __name__ == "__main__":
         "Test files can't be run directly. Use `python -m pytest greenery`"
     )
 
+import pytest
+
 from .bound import Bound, INF
 from .charclass import Charclass, DOT, NULLCHARCLASS, DIGIT
 from .multiplier import Multiplier, ONE, STAR, PLUS
@@ -17,16 +19,13 @@ def test_charclass_matching():
     assert match_charclass("aa", 1) == (Charclass("a"), 2)
     assert match_charclass("a$", 1) == (Charclass("$"), 2)
     assert match_charclass(".", 0) == (DOT, 1)
-    try:
+
+    with pytest.raises(IndexError):
         match_charclass("[", 0)
-        assert False
-    except IndexError:
-        pass
-    try:
+
+    with pytest.raises(NoMatch):
         match_charclass("a", 1)
-        assert False
-    except NoMatch:
-        pass
+
     assert match_charclass("[\\d]", 0) == (DIGIT, 4)
 
 

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -6,6 +6,7 @@ if __name__ == "__main__":
     )
 
 import pickle
+import pytest
 
 from .fsm import Fsm, ANYTHING_ELSE
 from .rxelems import from_fsm
@@ -152,11 +153,9 @@ def test_charclass_gen():
     assert next(gen) == "x"
     assert next(gen) == "y"
     assert next(gen) == "z"
-    try:
+
+    with pytest.raises(StopIteration):
         next(gen)
-        assert False
-    except StopIteration:
-        assert True
 
 
 def test_mult_gen():
@@ -164,20 +163,16 @@ def test_mult_gen():
     gen = parse("[ab]").strings()
     assert next(gen) == "a"
     assert next(gen) == "b"
-    try:
+
+    with pytest.raises(StopIteration):
         next(gen)
-        assert False
-    except StopIteration:
-        assert True
 
     # No terms
     gen = parse("[ab]{0}").strings()
     assert next(gen) == ""
-    try:
+
+    with pytest.raises(StopIteration):
         next(gen)
-        assert False
-    except StopIteration:
-        assert True
 
     # Many terms
     gen = parse("[ab]*").strings()
@@ -197,11 +192,9 @@ def test_conc_generator():
     assert next(gen) == "ad"
     assert next(gen) == "bc"
     assert next(gen) == "bd"
-    try:
+
+    with pytest.raises(StopIteration):
         next(gen)
-        assert False
-    except StopIteration:
-        assert True
 
 
 def test_pattern_generator():
@@ -211,11 +204,9 @@ def test_pattern_generator():
     assert next(gen) == "c"
     assert next(gen) == "d"
     assert next(gen) == "e"
-    try:
+
+    with pytest.raises(StopIteration):
         next(gen)
-        assert False
-    except StopIteration:
-        assert True
 
     # more complex
     gen = parse("abc|def(ghi|jkl)").strings()
@@ -251,11 +242,9 @@ def test_wildcard_generator():
     assert next(gen) == "aab"
     assert next(gen) == "abb"
     assert next(gen) == "a*b"
-    try:
+
+    with pytest.raises(StopIteration):
         next(gen)
-        assert False
-    except StopIteration:
-        assert True
 
 
 def test_forin():
@@ -273,11 +262,9 @@ def test_cardinality():
     assert parse("[ab]{3}").cardinality() == 8
     assert parse("[ab]{2,3}").cardinality() == 12
     assert len(parse("abc|def(ghi|jkl)")) == 3
-    try:
+
+    with pytest.raises(OverflowError):
         len(parse(".*"))
-        assert False
-    except OverflowError:
-        assert True
 
 
 ###############################################################################
@@ -472,13 +459,9 @@ def test_bad_alphabet():
                 0: {bad_symbol: 0}
             },
         )
-        try:
+
+        with pytest.raises(Exception, match="Symbol.*cannot be used"):
             from_fsm(f)
-            assert False
-        except AssertionError:
-            raise Exception(f"Accepted bad symbol: {repr(bad_symbol)}")
-        except Exception:
-            pass
 
 
 def test_dead_default():


### PR DESCRIPTION
Clearer than the previous pattern of catching `AssertionError` and then re-asserting `False`, and provides better stack traces.

This also improves a few of those tests to match on specific exception messages, since the exceptions are not currently typed in most cases.