### PR TITLE
fsm: validate transition source and symbols

### DIFF
--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -76,6 +76,12 @@ class Fsm:
             if state not in self.states:
                 raise Exception(f"Transition from unknown state {repr(state)}")
             for symbol in self.map[state]:
+                if symbol not in self.alphabet:
+                    raise Exception(
+                        f"Invalid symbol {repr(symbol)} "
+                        f"in transition from {repr(state)} "
+                        f"to {repr(self.map[state][symbol])}"
+                    )
                 if not self.map[state][symbol] in self.states:
                     raise Exception(
                         f"Transition for state {repr(state)} "

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -73,6 +73,8 @@ class Fsm:
                 f"must be a subset of {repr(self.states)}"
             )
         for state, symbol in self.map.items():
+            if state not in self.states:
+                raise Exception(f"Transition from unknown state {repr(state)}")
             for symbol in self.map[state]:
                 if not self.map[state][symbol] in self.states:
                     raise Exception(

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -460,6 +460,16 @@ def test_invalid_fsms():
             }
         )
 
+    # invalid transition table includes symbol outside of alphabet
+    with pytest.raises(Exception, match="Invalid symbol"):
+        Fsm(
+            alphabet={"a"},
+            states={1, 2},
+            initial=1,
+            finals=set(),
+            map={1: {"a": 2, "b": 2}},
+        )
+
 
 def test_bad_multiplier(a):
     with pytest.raises(Exception, match="Can't multiply"):

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -448,6 +448,18 @@ def test_invalid_fsms():
             }
         )
 
+    # invalid transition from unknown state
+    with pytest.raises(Exception, match="Transition.+unknown state"):
+        Fsm(
+            alphabet={"a"},
+            states={1, 2},
+            initial=1,
+            finals=set(),
+            map={
+                3: {"a": 2}
+            }
+        )
+
 
 def test_bad_multiplier(a):
     with pytest.raises(Exception, match="Can't multiply"):


### PR DESCRIPTION
Previously the `Fsm` constructor did not validate that transition sources were in `states` or that that the symbols were in `alphabet`.

Since neither is inferred from the transition map, nor is it inferred from them, it was possible to construct an `Fsm` in which iterating over `self.map` would give values inconsistent with those sets.

This is arguably unnecessary work, but seemed inconsistent and likely just overlooked since validations exist for the destination states, the initial state, and terminals states.

This PR includes tests written in the current style, however I have a resolution for #70 prepared depending on preferred merge order.