### PR TITLE
types: `reversed()` builtin is only typed to return an `Iterator`

### DIFF
--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -121,7 +121,7 @@ class Fsm:
             machine equivalent to the original can be obtained by reversing the
             original twice.
         '''
-        return reversed(reversed(self))
+        return self.reversed().reversed()
 
     def __repr__(self):
         args = ", ".join([

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -309,7 +309,7 @@ def test_reverse_abc():
             None: {"a": None, "b": None, "c": None},
         },
     )
-    cba = reversed(abc)
+    cba = abc.reversed()
     assert cba.accepts("cba")
 
 
@@ -341,7 +341,7 @@ def test_reverse_brzozowski():
     assert not brzozowski.accepts("bbbbbbbbbbbb")
 
     # So this is (a|b)a(a|b)*
-    b2 = reversed(brzozowski)
+    b2 = brzozowski.reversed()
     assert b2.accepts("aa")
     assert b2.accepts("ba")
     assert b2.accepts("baa")
@@ -367,7 +367,7 @@ def test_reverse_brzozowski():
 
 def test_reverse_epsilon():
     # epsilon reversed is epsilon
-    assert reversed(epsilon("a")).accepts("")
+    assert epsilon("a").reversed().accepts("")
 
 
 def test_binary_3():
@@ -703,7 +703,7 @@ def test_oblivion_crawl(a):
     assert len((abc + abc).states) == 7
     assert len(abc.star().states) == 3
     assert len((abc * 3).states) == 10
-    assert len(reversed(abc).states) == 4
+    assert len(abc.reversed().states) == 4
     assert len((abc | abc).states) == 4
     assert len((abc & abc).states) == 4
     assert len((abc ^ abc).states) == 1

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -257,7 +257,7 @@ class Conc():
         return self.reversed().dock(other.reversed()).reversed()
 
     def reversed(self):
-        return Conc(*reversed([mult.reversed() for mult in self.mults]))
+        return Conc(*[mult.reversed() for mult in reversed(self.mults)])
 
 
 def from_fsm(f: Fsm):

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -573,12 +573,12 @@ def test_equivalence():
 # Test reversed()
 
 def test_regex_reversal():
-    assert reversed(parse("b")) == parse("b")
-    assert reversed(parse("e*")) == parse("e*")
-    assert reversed(parse("bear")) == parse("raeb")
-    assert reversed(parse("beer")) == parse("reeb")
-    assert reversed(parse("abc|def|ghi")) == parse("cba|fed|ihg")
-    assert reversed(parse("(abc)*d")) == parse("d(cba)*")
+    assert parse("b").reversed() == parse("b")
+    assert parse("e*").reversed() == parse("e*")
+    assert parse("bear").reversed() == parse("raeb")
+    assert parse("beer").reversed() == parse("reeb")
+    assert parse("abc|def|ghi").reversed() == parse("cba|fed|ihg")
+    assert parse("(abc)*d").reversed() == parse("d(cba)*")
 
 
 ###############################################################################
@@ -755,8 +755,8 @@ def test_silly_reduction():
         "(aa|bb*aa)a*|((ab|bb*ab)|(aa|bb*aa)a*b)" + \
         "((ab|bb*ab)|(aa|bb*aa)a*b)*"
     long = parse(long)
-    long = reversed(long.to_fsm())
-    long = reversed(from_fsm(long))
+    long = long.to_fsm().reversed()
+    long = from_fsm(long).reversed()
     assert str(long) == "[ab]*a[ab]"
     short = "[ab]*a?b*|[ab]*b?a*"
     assert str(parse(".*") & parse(short)) == "[ab]*"


### PR DESCRIPTION
Although the classes here return specialised instances from `__reverse__`, `reversed()` itself may be an object which delegates to that iterable, in the same way that e.g. `map()` or `enumerate()` does.

This rightly causes linters to complain that `reversed()` doesn't return a `Pattern`, etc, as assumed by some parts of the code.

This preserves the existing iterable `__reversed__` dunder method, but internally updates to use `.reversed()` whenever the container type is required to be consistent.