### PR TITLE
lint: consistent import order with `isort`, add explicit `__all__` exports

### DIFF
--- a/.github/workflows/workflow-1.yml
+++ b/.github/workflows/workflow-1.yml
@@ -22,8 +22,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        pip install flake8 pytest isort
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with isort
+      run: |
+        isort --quiet --diff --check .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,5 @@
+[settings]
+profile = black
+add_imports = from __future__ import annotations
+remove_redundant_aliases = true
+combine_as_imports = true

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Special `Bound` representing no limit. Can be used as an upper bound only.
 ### Running tests
 
 ```sh
+isort .
 flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 flake8 . --count --exit-zero --max-complexity=10 --max-line-length=80 --statistics
 pytest

--- a/greenery/__init__.py
+++ b/greenery/__init__.py
@@ -5,6 +5,7 @@ __all__ = (
     "INF",
     "Multiplier",
     "PLUS",
+    "Pattern",
     "QM",
     "STAR",
     "parse",
@@ -13,3 +14,4 @@ __all__ = (
 from .bound import INF, Bound
 from .multiplier import PLUS, QM, STAR, Multiplier
 from .parse import parse
+from .rxelems import Pattern

--- a/greenery/__init__.py
+++ b/greenery/__init__.py
@@ -1,12 +1,12 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
 
 # In theory this should just pull in the `parse` function, but it turns out
 # that the act of performing any relative import suddenly makes EVERY MODULE
 # AVAILABLE IN SCOPE?
 # Ignore errors because we are in fact importing these values to re-export them
+from .bound import INF, Bound  # noqa: F401
+from .multiplier import PLUS, QM, STAR, Multiplier  # noqa: F401
 from .parse import parse  # noqa: F401
-from .bound import Bound, INF  # noqa: F401
-from .multiplier import Multiplier, QM, STAR, PLUS  # noqa: F401
 
 # WHY ARE THESE MODULE OBJECTS IN SCOPE SUDDENLY? I DIDN'T ASK FOR THEM
 # print(bound, fsm, charclass, rxelems)

--- a/greenery/__init__.py
+++ b/greenery/__init__.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-# In theory this should just pull in the `parse` function, but it turns out
-# that the act of performing any relative import suddenly makes EVERY MODULE
-# AVAILABLE IN SCOPE?
-# Ignore errors because we are in fact importing these values to re-export them
-from .bound import INF, Bound  # noqa: F401
-from .multiplier import PLUS, QM, STAR, Multiplier  # noqa: F401
-from .parse import parse  # noqa: F401
+__all__ = (
+    "Bound",
+    "INF",
+    "Multiplier",
+    "PLUS",
+    "QM",
+    "STAR",
+    "parse",
+)
 
-# WHY ARE THESE MODULE OBJECTS IN SCOPE SUDDENLY? I DIDN'T ASK FOR THEM
-# print(bound, fsm, charclass, rxelems)
-
-# This, however, is the *function*, *not* its containing module object?
-# print(parse)
+from .bound import INF, Bound
+from .multiplier import PLUS, QM, STAR, Multiplier
+from .parse import parse

--- a/greenery/bound.py
+++ b/greenery/bound.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+__all__ = (
+    "Bound",
+    "INF",
+)
+
 from dataclasses import dataclass
 from typing import Optional
 

--- a/greenery/bound.py
+++ b/greenery/bound.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Optional

--- a/greenery/bound_test.py
+++ b/greenery/bound_test.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
 
-from .bound import Bound, INF
+from .bound import INF, Bound
 
 
 def test_bound_str():

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -1,9 +1,9 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Union, FrozenSet
+from typing import FrozenSet, Union
 
-from .fsm import Fsm, ANYTHING_ELSE
+from .fsm import ANYTHING_ELSE, Fsm
 
 
 @dataclass(frozen=True)

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -1,5 +1,19 @@
 from __future__ import annotations
 
+__all__ = (
+    "Charclass",
+    "DIGIT",
+    "DOT",
+    "NONDIGITCHAR",
+    "NONSPACECHAR",
+    "NONWORDCHAR",
+    "NULLCHARCLASS",
+    "SPACECHAR",
+    "WORDCHAR",
+    "escapes",
+    "shorthand",
+)
+
 from dataclasses import dataclass
 from typing import FrozenSet, Union
 

--- a/greenery/charclass_test.py
+++ b/greenery/charclass_test.py
@@ -1,7 +1,16 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
 
-from .charclass import Charclass, WORDCHAR, DIGIT, SPACECHAR, NONWORDCHAR, \
-    NONDIGITCHAR, NONSPACECHAR, DOT, NULLCHARCLASS
+from .charclass import (
+    DIGIT,
+    DOT,
+    NONDIGITCHAR,
+    NONSPACECHAR,
+    NONWORDCHAR,
+    NULLCHARCLASS,
+    SPACECHAR,
+    WORDCHAR,
+    Charclass,
+)
 from .fsm import ANYTHING_ELSE
 
 

--- a/greenery/conc_test.py
+++ b/greenery/conc_test.py
@@ -1,11 +1,11 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
 
 import pytest
 
 from .bound import Bound
-from .multiplier import Multiplier, ZERO, QM, ONE, STAR, PLUS
 from .charclass import Charclass
-from .rxelems import Conc, Mult, EMPTYSTRING
+from .multiplier import ONE, PLUS, QM, STAR, ZERO, Multiplier
+from .rxelems import EMPTYSTRING, Conc, Mult
 
 
 def test_conc_equality():

--- a/greenery/conc_test.py
+++ b/greenery/conc_test.py
@@ -5,7 +5,7 @@ import pytest
 from .bound import Bound
 from .charclass import Charclass
 from .multiplier import ONE, PLUS, QM, STAR, ZERO, Multiplier
-from .rxelems import EMPTYSTRING, Conc, Mult
+from .rxelems import Conc, Mult
 
 
 def test_conc_equality():
@@ -17,7 +17,7 @@ def test_conc_equality():
         Charclass("a"),
         Multiplier(Bound(1), Bound(2)))
     )
-    assert a != EMPTYSTRING
+    assert a != Conc()
 
 
 def test_conc_str():

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -1,11 +1,11 @@
-# -*- coding: utf-8 -*-
-
 '''
     Finite state machine library, intended to be used by `greenery` only
 '''
 
-from typing import Optional, Union, Set, Dict
+from __future__ import annotations
+
 from dataclasses import dataclass
+from typing import Dict, Optional, Set, Union
 
 ANYTHING_ELSE = '9bd74361-04f9-4742-9d3a-1d14a6f0044c'
 

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -4,6 +4,14 @@
 
 from __future__ import annotations
 
+__all__ = (
+    "ANYTHING_ELSE",
+    "Fsm",
+    "alphabet_key",
+    "epsilon",
+    "null",
+)
+
 from dataclasses import dataclass
 from typing import Dict, Optional, Set, Union
 

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -1,8 +1,8 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
 
 import pytest
 
-from .fsm import Fsm, null, epsilon, ANYTHING_ELSE
+from .fsm import ANYTHING_ELSE, Fsm, epsilon, null
 
 
 def test_addbug():

--- a/greenery/mult_test.py
+++ b/greenery/mult_test.py
@@ -1,9 +1,9 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
 
+from .bound import INF, Bound
+from .charclass import DIGIT, Charclass
 from .fsm import ANYTHING_ELSE
-from .charclass import Charclass, DIGIT
-from .bound import Bound, INF
-from .multiplier import Multiplier, ONE, QM, STAR, PLUS
+from .multiplier import ONE, PLUS, QM, STAR, Multiplier
 from .rxelems import Mult
 
 

--- a/greenery/multiplier.py
+++ b/greenery/multiplier.py
@@ -1,5 +1,15 @@
 from __future__ import annotations
 
+__all__ = (
+    "Multiplier",
+    "ONE",
+    "PLUS",
+    "QM",
+    "STAR",
+    "ZERO",
+    "symbolic",
+)
+
 from dataclasses import dataclass, field
 
 from .bound import INF, Bound

--- a/greenery/multiplier.py
+++ b/greenery/multiplier.py
@@ -1,8 +1,8 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from .bound import Bound, INF
+from .bound import INF, Bound
 
 
 @dataclass(frozen=True)

--- a/greenery/multiplier_test.py
+++ b/greenery/multiplier_test.py
@@ -1,9 +1,9 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
 
 import pytest
 
-from .bound import Bound, INF
-from .multiplier import Multiplier, ZERO, ONE, QM, STAR, PLUS
+from .bound import INF, Bound
+from .multiplier import ONE, PLUS, QM, STAR, ZERO, Multiplier
 
 
 def test_multiplier_str():

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+__all__ = (
+    "parse",
+    "NoMatch",
+)
+
 from typing import Tuple
 
 from .bound import INF, Bound

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -1,11 +1,11 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
 
 from typing import Tuple
 
-from .bound import Bound, INF
-from .charclass import Charclass, shorthand, escapes
+from .bound import INF, Bound
+from .charclass import Charclass, escapes, shorthand
 from .multiplier import Multiplier, symbolic
-from .rxelems import Pattern, Conc, Mult
+from .rxelems import Conc, Mult, Pattern
 
 
 class NoMatch(Exception):

--- a/greenery/parse_test.py
+++ b/greenery/parse_test.py
@@ -5,6 +5,8 @@ import pytest
 from .bound import INF, Bound
 from .charclass import DIGIT, DOT, NULLCHARCLASS, Charclass
 from .multiplier import ONE, PLUS, STAR, Multiplier
+
+# noinspection PyProtectedMember
 from .parse import NoMatch, match_charclass, match_mult, parse
 from .rxelems import Conc, Mult, Pattern
 

--- a/greenery/parse_test.py
+++ b/greenery/parse_test.py
@@ -1,17 +1,17 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import pytest
+
+from .bound import INF, Bound
+from .charclass import DIGIT, DOT, NULLCHARCLASS, Charclass
+from .multiplier import ONE, PLUS, STAR, Multiplier
+from .parse import NoMatch, match_charclass, match_mult, parse
+from .rxelems import Conc, Mult, Pattern
 
 if __name__ == "__main__":
     raise Exception(
         "Test files can't be run directly. Use `python -m pytest greenery`"
     )
-
-import pytest
-
-from .bound import Bound, INF
-from .charclass import Charclass, DOT, NULLCHARCLASS, DIGIT
-from .multiplier import Multiplier, ONE, STAR, PLUS
-from .rxelems import Mult, Conc, Pattern
-from .parse import NoMatch, match_charclass, parse, match_mult
 
 
 def test_charclass_matching():

--- a/greenery/pattern_test.py
+++ b/greenery/pattern_test.py
@@ -1,9 +1,9 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
 
 from .charclass import Charclass
 from .multiplier import ONE, ZERO
-from .rxelems import Pattern, Conc, Mult
 from .parse import parse
+from .rxelems import Conc, Mult, Pattern
 
 
 def test_pattern_equality():

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -1,17 +1,18 @@
-# -*- coding: utf-8 -*-
-
 '''
     Because of the circularity between `Pattern`, `Conc` and `Mult`, all three
     need to be in the same source file?
 '''
 
+from __future__ import annotations
+
 from dataclasses import dataclass
+from functools import reduce
 from typing import Union
 
-from .fsm import Fsm, ANYTHING_ELSE, null, epsilon, alphabet_key
-from .multiplier import Multiplier, ZERO, QM, ONE, STAR
-from .charclass import Charclass, NULLCHARCLASS
-from .bound import Bound, INF
+from .bound import INF, Bound
+from .charclass import NULLCHARCLASS, Charclass
+from .fsm import ANYTHING_ELSE, Fsm, alphabet_key, epsilon, null
+from .multiplier import ONE, QM, STAR, ZERO, Multiplier
 
 
 @dataclass(frozen=True)
@@ -630,7 +631,6 @@ class Pattern:
         if len(self.concs) == 0:
             raise Exception(f"Can't call _commonconc on {repr(self)}")
 
-        from functools import reduce
         return reduce(
             lambda x, y: x.common(y, suffix=suffix),
             self.concs

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -5,6 +5,13 @@
 
 from __future__ import annotations
 
+__all__ = (
+    "Conc",
+    "Mult",
+    "Pattern",
+    "from_fsm",
+)
+
 from dataclasses import dataclass
 from functools import reduce
 from typing import Union

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -1,17 +1,19 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import pickle
+import time
+
+import pytest
+
+from .charclass import DIGIT, WORDCHAR
+from .fsm import ANYTHING_ELSE, Fsm
+from .parse import parse
+from .rxelems import from_fsm
 
 if __name__ == "__main__":
     raise Exception(
         "Test files can't be run directly. Use `python -m pytest greenery`"
     )
-
-import pickle
-import pytest
-
-from .fsm import Fsm, ANYTHING_ELSE
-from .rxelems import from_fsm
-from .charclass import DIGIT, WORDCHAR
-from .parse import parse
 
 
 ###############################################################################
@@ -930,7 +932,6 @@ def test_isdisjoint():
 
 def test_bug_slow():
     # issue #43
-    import time
     m = Fsm(
         alphabet={'R', 'L', 'U', 'D'},
         states={

--- a/main.py
+++ b/main.py
@@ -1,4 +1,6 @@
-from greenery import Bound, INF, Multiplier, PLUS, QM, STAR, parse
+from __future__ import annotations
+
+from greenery import INF, PLUS, QM, STAR, Bound, Multiplier, parse
 
 pattern = parse("a")
 print(pattern)  # "a"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import setup
 
 setup(


### PR DESCRIPTION
This PR modernizes import/export style a bit.

The main thrust is:
  1. Remove the python 2-era `coding: utf8` header. Not needed in Python 3.
  2. Prepend `from __future__ import annotations` to the modules. Safe, improves performance, and allows more modern types (not included here).
  3. Adds `isort` to sort the imports automatically, and makes those imports all consistent. Includes update to the `workflow.yaml`.
  4. Adds explicit symbol exports via `__all__` to each of the modules.