### PR TITLE
ci: add `mypy` + minimum type fixes

### DIFF
--- a/.github/workflows/workflow-1.yml
+++ b/.github/workflows/workflow-1.yml
@@ -22,8 +22,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest mypy
+        pip install flake8 pytest mypy isort
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with isort
+      run: |
+        isort --quiet --diff --check .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/workflow-1.yml
+++ b/.github/workflows/workflow-1.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        pip install flake8 pytest mypy
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
@@ -30,6 +30,9 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings
         flake8 . --count --exit-zero --max-line-length=80 --statistics
+    - name: Check with mypy
+      run: |
+        mypy greenery
     - name: Test with pytest
       run: |
         pytest

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,5 @@
+[settings]
+profile = black
+add_imports = from __future__ import annotations
+remove_redundant_aliases = true
+combine_as_imports = true

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Special `Bound` representing no limit. Can be used as an upper bound only.
 ### Running tests
 
 ```sh
+mypy greenery
 flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 flake8 . --count --exit-zero --max-complexity=10 --max-line-length=80 --statistics
 pytest

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Special `Bound` representing no limit. Can be used as an upper bound only.
 ### Running tests
 
 ```sh
+isort .
 mypy greenery
 flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 flake8 . --count --exit-zero --max-complexity=10 --max-line-length=80 --statistics

--- a/greenery/__init__.py
+++ b/greenery/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 # In theory this should just pull in the `parse` function, but it turns out
 # that the act of performing any relative import suddenly makes EVERY MODULE
 # AVAILABLE IN SCOPE?

--- a/greenery/__init__.py
+++ b/greenery/__init__.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
-# In theory this should just pull in the `parse` function, but it turns out
-# that the act of performing any relative import suddenly makes EVERY MODULE
-# AVAILABLE IN SCOPE?
-# Ignore errors because we are in fact importing these values to re-export them
-from .parse import parse  # noqa: F401
-from .bound import Bound, INF  # noqa: F401
-from .multiplier import Multiplier, QM, STAR, PLUS  # noqa: F401
+__all__ = (
+    "Bound",
+    "INF",
+    "Multiplier",
+    "PLUS",
+    "Pattern",
+    "QM",
+    "STAR",
+    "parse",
+)
 
-# WHY ARE THESE MODULE OBJECTS IN SCOPE SUDDENLY? I DIDN'T ASK FOR THEM
-# print(bound, fsm, charclass, rxelems)
-
-# This, however, is the *function*, *not* its containing module object?
-# print(parse)
+from .bound import INF, Bound
+from .multiplier import PLUS, QM, STAR, Multiplier
+from .parse import parse
+from .rxelems import Pattern

--- a/greenery/__init__.py
+++ b/greenery/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # In theory this should just pull in the `parse` function, but it turns out
 # that the act of performing any relative import suddenly makes EVERY MODULE
 # AVAILABLE IN SCOPE?

--- a/greenery/bound.py
+++ b/greenery/bound.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional
 

--- a/greenery/bound.py
+++ b/greenery/bound.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass(frozen=True)
 class Bound:
     '''An integer but sometimes also possibly infinite (None)'''
-    v: Optional[int]
+    v: int | None
 
     def __post_init__(self):
         if self.v is not None and self.v < 0:

--- a/greenery/bound.py
+++ b/greenery/bound.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from dataclasses import dataclass
 from typing import Optional
 

--- a/greenery/bound.py
+++ b/greenery/bound.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+__all__ = (
+    "Bound",
+    "INF",
+)
+
 from dataclasses import dataclass
 
 

--- a/greenery/bound_test.py
+++ b/greenery/bound_test.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from .bound import Bound, INF
 
 

--- a/greenery/bound_test.py
+++ b/greenery/bound_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .bound import Bound, INF
 
 

--- a/greenery/bound_test.py
+++ b/greenery/bound_test.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .bound import Bound, INF
+from .bound import INF, Bound
 
 
 def test_bound_str():

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -1,8 +1,22 @@
 from __future__ import annotations
 
+__all__ = (
+    "Charclass",
+    "DIGIT",
+    "DOT",
+    "NONDIGITCHAR",
+    "NONSPACECHAR",
+    "NONWORDCHAR",
+    "NULLCHARCLASS",
+    "SPACECHAR",
+    "WORDCHAR",
+    "escapes",
+    "shorthand",
+)
+
 from dataclasses import dataclass
 
-from .fsm import Fsm, ANYTHING_ELSE
+from .fsm import ANYTHING_ELSE, Fsm
 
 
 @dataclass(frozen=True)

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Union, FrozenSet
 
 from .fsm import Fsm, ANYTHING_ELSE
 
@@ -16,7 +15,7 @@ class Charclass:
         if the full alphabet is extremely large, but also requires dedicated
         combination functions.
     '''
-    chars: Union[FrozenSet[str], str]
+    chars: frozenset[str] | str
     negated: bool = False
 
     def __post_init__(self):

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from dataclasses import dataclass
 from typing import Union, FrozenSet
 

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Union, FrozenSet
 

--- a/greenery/charclass_test.py
+++ b/greenery/charclass_test.py
@@ -1,7 +1,16 @@
 from __future__ import annotations
 
-from .charclass import Charclass, WORDCHAR, DIGIT, SPACECHAR, NONWORDCHAR, \
-    NONDIGITCHAR, NONSPACECHAR, DOT, NULLCHARCLASS
+from .charclass import (
+    DIGIT,
+    DOT,
+    NONDIGITCHAR,
+    NONSPACECHAR,
+    NONWORDCHAR,
+    NULLCHARCLASS,
+    SPACECHAR,
+    WORDCHAR,
+    Charclass,
+)
 from .fsm import ANYTHING_ELSE
 
 

--- a/greenery/charclass_test.py
+++ b/greenery/charclass_test.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from .charclass import Charclass, WORDCHAR, DIGIT, SPACECHAR, NONWORDCHAR, \
     NONDIGITCHAR, NONSPACECHAR, DOT, NULLCHARCLASS
 from .fsm import ANYTHING_ELSE

--- a/greenery/charclass_test.py
+++ b/greenery/charclass_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .charclass import Charclass, WORDCHAR, DIGIT, SPACECHAR, NONWORDCHAR, \
     NONDIGITCHAR, NONSPACECHAR, DOT, NULLCHARCLASS
 from .fsm import ANYTHING_ELSE

--- a/greenery/conc_test.py
+++ b/greenery/conc_test.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import pytest
 
 from .bound import Bound
-from .multiplier import Multiplier, ZERO, QM, ONE, STAR, PLUS
 from .charclass import Charclass
-from .rxelems import Conc, Mult, EMPTYSTRING
+from .multiplier import ONE, PLUS, QM, STAR, ZERO, Multiplier
+from .rxelems import Conc, Mult
 
 
 def test_conc_equality():
@@ -17,7 +17,7 @@ def test_conc_equality():
         Charclass("a"),
         Multiplier(Bound(1), Bound(2)))
     )
-    assert a != EMPTYSTRING
+    assert a != Conc()
 
 
 def test_conc_str():

--- a/greenery/conc_test.py
+++ b/greenery/conc_test.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import pytest
 
 from .bound import Bound

--- a/greenery/conc_test.py
+++ b/greenery/conc_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from .bound import Bound

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -4,8 +4,17 @@
 
 from __future__ import annotations
 
-from typing import Union
+__all__ = (
+    "ANYTHING_ELSE",
+    "Fsm",
+    "alphabet_key",
+    "epsilon",
+    "null",
+    "state_type",
+)
+
 from dataclasses import dataclass
+from typing import Union
 
 ANYTHING_ELSE = '9bd74361-04f9-4742-9d3a-1d14a6f0044c'
 

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -2,6 +2,8 @@
     Finite state machine library, intended to be used by `greenery` only
 '''
 
+from __future__ import annotations
+
 from typing import Optional, Union, Set, Dict
 from dataclasses import dataclass
 

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union, Set, Dict
+from typing import Union
 from dataclasses import dataclass
 
 ANYTHING_ELSE = '9bd74361-04f9-4742-9d3a-1d14a6f0044c'
@@ -26,7 +26,7 @@ class OblivionError(Exception):
     pass
 
 
-state_type = Optional[Union[int, str]]
+state_type = Union[int, str, None]
 
 
 @dataclass(frozen=True)
@@ -45,10 +45,10 @@ class Fsm:
         The majority of these methods are available using operator overloads.
     '''
     initial: state_type
-    finals: Set[state_type]
-    alphabet: Set[str]
-    states: Set[state_type]
-    map: Dict[state_type, Dict[str, state_type]]
+    finals: set[state_type]
+    alphabet: set[str]
+    states: set[state_type]
+    map: dict[state_type, dict[str, state_type]]
 
     def __post_init__(self):
         '''

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -72,7 +72,7 @@ class Fsm:
                 f"Final states {repr(self.finals)} "
                 f"must be a subset of {repr(self.states)}"
             )
-        for state, symbol in self.map.items():
+        for state, _state_trans in self.map.items():
             if state not in self.states:
                 raise Exception(f"Transition from unknown state {repr(state)}")
             for symbol in self.map[state]:

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 '''
     Finite state machine library, intended to be used by `greenery` only
 '''

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from .fsm import Fsm, null, epsilon, ANYTHING_ELSE

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from .fsm import Fsm, null, epsilon, ANYTHING_ELSE
+from .fsm import ANYTHING_ELSE, Fsm, epsilon, null
 
 
 def test_addbug():

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import pytest
 
 from .fsm import Fsm, null, epsilon, ANYTHING_ELSE

--- a/greenery/mult_test.py
+++ b/greenery/mult_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .fsm import ANYTHING_ELSE
 from .charclass import Charclass, DIGIT
 from .bound import Bound, INF

--- a/greenery/mult_test.py
+++ b/greenery/mult_test.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from .bound import INF, Bound
+from .charclass import DIGIT, Charclass
 from .fsm import ANYTHING_ELSE
-from .charclass import Charclass, DIGIT
-from .bound import Bound, INF
-from .multiplier import Multiplier, ONE, QM, STAR, PLUS
+from .multiplier import ONE, PLUS, QM, STAR, Multiplier
 from .rxelems import Mult
 
 

--- a/greenery/mult_test.py
+++ b/greenery/mult_test.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from .fsm import ANYTHING_ELSE
 from .charclass import Charclass, DIGIT
 from .bound import Bound, INF

--- a/greenery/multiplier.py
+++ b/greenery/multiplier.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 
 from .bound import Bound, INF

--- a/greenery/multiplier.py
+++ b/greenery/multiplier.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
+__all__ = (
+    "Multiplier",
+    "ONE",
+    "PLUS",
+    "QM",
+    "STAR",
+    "ZERO",
+    "symbolic",
+)
+
 from dataclasses import dataclass, field
 
-from .bound import Bound, INF
+from .bound import INF, Bound
 
 
 @dataclass(frozen=True)

--- a/greenery/multiplier.py
+++ b/greenery/multiplier.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from dataclasses import dataclass, field
 
 from .bound import Bound, INF

--- a/greenery/multiplier_test.py
+++ b/greenery/multiplier_test.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import pytest
 
-from .bound import Bound, INF
-from .multiplier import Multiplier, ZERO, ONE, QM, STAR, PLUS
+from .bound import INF, Bound
+from .multiplier import ONE, PLUS, QM, STAR, ZERO, Multiplier
 
 
 def test_multiplier_str():

--- a/greenery/multiplier_test.py
+++ b/greenery/multiplier_test.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import pytest
 
 from .bound import Bound, INF

--- a/greenery/multiplier_test.py
+++ b/greenery/multiplier_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from .bound import Bound, INF

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Tuple
 
 from .bound import Bound, INF

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Tuple
-
 from .bound import Bound, INF
 from .charclass import Charclass, shorthand, escapes
 from .multiplier import Multiplier, symbolic
@@ -16,7 +14,7 @@ class NoMatch(Exception):
     pass
 
 
-def read_until(string: str, i: int, stop_char: str) -> Tuple[int, str]:
+def read_until(string: str, i: int, stop_char: str) -> tuple[int, str]:
     start = i
     while True:
         if i >= len(string):

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from typing import Tuple
 
 from .bound import Bound, INF

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
-from .bound import Bound, INF
-from .charclass import Charclass, shorthand, escapes
+__all__ = (
+    "parse",
+    "NoMatch",
+)
+
+from .bound import INF, Bound
+from .charclass import Charclass, escapes, shorthand
 from .multiplier import Multiplier, symbolic
-from .rxelems import Pattern, Conc, Mult
+from .rxelems import Conc, Mult, Pattern
 
 
 class NoMatch(Exception):

--- a/greenery/parse_test.py
+++ b/greenery/parse_test.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
+import pytest
+
+from .bound import INF, Bound
+from .charclass import DIGIT, DOT, NULLCHARCLASS, Charclass
+from .multiplier import ONE, PLUS, STAR, Multiplier
+
+# noinspection PyProtectedMember
+from .parse import NoMatch, match_charclass, match_mult, parse
+from .rxelems import Conc, Mult, Pattern
+
 if __name__ == "__main__":
     raise Exception(
         "Test files can't be run directly. Use `python -m pytest greenery`"
     )
-
-import pytest
-
-from .bound import Bound, INF
-from .charclass import Charclass, DOT, NULLCHARCLASS, DIGIT
-from .multiplier import Multiplier, ONE, STAR, PLUS
-from .rxelems import Mult, Conc, Pattern
-from .parse import NoMatch, match_charclass, parse, match_mult
 
 
 def test_charclass_matching():

--- a/greenery/parse_test.py
+++ b/greenery/parse_test.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 if __name__ == "__main__":
     raise Exception(
         "Test files can't be run directly. Use `python -m pytest greenery`"

--- a/greenery/parse_test.py
+++ b/greenery/parse_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 if __name__ == "__main__":
     raise Exception(
         "Test files can't be run directly. Use `python -m pytest greenery`"

--- a/greenery/pattern_test.py
+++ b/greenery/pattern_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .charclass import Charclass
 from .multiplier import ONE, ZERO
 from .rxelems import Pattern, Conc, Mult

--- a/greenery/pattern_test.py
+++ b/greenery/pattern_test.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from .charclass import Charclass
 from .multiplier import ONE, ZERO
 from .rxelems import Pattern, Conc, Mult

--- a/greenery/pattern_test.py
+++ b/greenery/pattern_test.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from .charclass import Charclass
 from .multiplier import ONE, ZERO
-from .rxelems import Pattern, Conc, Mult
 from .parse import parse
+from .rxelems import Conc, Mult, Pattern
 
 
 def test_pattern_equality():

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -5,13 +5,21 @@
 
 from __future__ import annotations
 
+__all__ = (
+    "Conc",
+    "Mult",
+    "Pattern",
+    "from_fsm",
+)
+
 from dataclasses import dataclass
 from enum import Enum, auto
+from functools import reduce
 
-from .fsm import Fsm, ANYTHING_ELSE, null, epsilon, alphabet_key, state_type
-from .multiplier import Multiplier, ZERO, QM, ONE, STAR
-from .charclass import Charclass, NULLCHARCLASS
-from .bound import Bound, INF
+from .bound import INF, Bound
+from .charclass import NULLCHARCLASS, Charclass
+from .fsm import ANYTHING_ELSE, Fsm, alphabet_key, epsilon, null, state_type
+from .multiplier import ONE, QM, STAR, ZERO, Multiplier
 
 
 @dataclass(frozen=True)
@@ -643,7 +651,6 @@ class Pattern:
         if len(self.concs) == 0:
             raise Exception(f"Can't call _commonconc on {repr(self)}")
 
-        from functools import reduce
         return reduce(
             lambda x, y: x.common(y, suffix=suffix),
             self.concs

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -37,7 +37,7 @@ class Conc():
         args = ", ".join(repr(mult) for mult in self.mults)
         return f"Conc({args})"
 
-    def reduce(self):
+    def reduce(self) -> Conc:
         if self == NULLCONC:
             return self
 
@@ -465,7 +465,7 @@ class Pattern:
             raise Exception(f"Can't serialise {repr(self)}")
         return "|".join(sorted(str(conc) for conc in self.concs))
 
-    def reduce(self):
+    def reduce(self) -> Pattern:
         if self == NULLPATTERN:
             return self
 
@@ -820,7 +820,7 @@ class Mult:
     def empty(self):
         return self.multiplicand.empty() and self.multiplier.min > Bound(0)
 
-    def reduce(self):
+    def reduce(self) -> Mult:
         if self == NULLMULT:
             return self
 

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 '''
     Because of the circularity between `Pattern`, `Conc` and `Mult`, all three
     need to be in the same source file?

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -550,8 +550,7 @@ class Pattern:
                    and conc.mults[0].multiplier.min == Bound(0):
                     # Then we can omit the empty string.
                     # E.g. "|(ab)*|def" => "(ab)*|def".
-                    rest = self.concs - {EMPTYSTRING}
-                    return Pattern(*rest).reduce()
+                    return Pattern(*(self.concs - {EMPTYSTRING})).reduce()
 
             for conc in self.concs:
                 # ...and there is another `Conc`
@@ -566,8 +565,9 @@ class Pattern:
                             conc.mults[0].multiplier * QM
                         )
                     )
-                    rest = self.concs - {EMPTYSTRING, conc} | {merged_conc}
-                    return Pattern(*rest).reduce()
+                    return Pattern(
+                        *(self.concs - {EMPTYSTRING, conc} | {merged_conc})
+                    ).reduce()
 
         # If the present `Pattern`'s `Conc`s all have a common prefix, split
         # that out. This increases the depth of the object

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -21,6 +21,9 @@ class Conc():
         e.g. abcde[^fg]*h{4}[a-z]+(subpattern)(subpattern2)
         To express the empty string, use an empty `Conc`, Conc().
     '''
+
+    mults: tuple[Mult, ...]
+
     def __init__(self, *mults):
         object.__setattr__(self, "mults", tuple(mults))
 
@@ -406,6 +409,9 @@ class Pattern:
         subpattern, "ghi|jkl". This new subpattern again consists of two
         `Conc`s: "ghi" and "jkl".
     '''
+
+    concs: frozenset[Conc]
+
     def __init__(self, *concs):
         object.__setattr__(self, "concs", frozenset(concs))
 

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -270,7 +270,7 @@ class _Outside(Enum):
     TOKEN = auto()
 
 
-def from_fsm(f: Fsm):
+def from_fsm(f: Fsm) -> Pattern:
     '''
         Turn the supplied finite state machine into a `Pattern`. This is
         accomplished using the Brzozowski algebraic method.

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum, auto
 
 from .fsm import Fsm, ANYTHING_ELSE, null, epsilon, alphabet_key
 from .multiplier import Multiplier, ZERO, QM, ONE, STAR
@@ -262,6 +263,13 @@ class Conc():
         return Conc(*[mult.reversed() for mult in reversed(self.mults)])
 
 
+# We need a new state not already used.
+class _Outside(Enum):
+    """Marker state for use in `from_fsm`."""
+
+    TOKEN = auto()
+
+
 def from_fsm(f: Fsm):
     '''
         Turn the supplied finite state machine into a `Pattern`. This is
@@ -278,8 +286,7 @@ def from_fsm(f: Fsm):
             f"Symbol {repr(symbol)} cannot be used in a regular expression"
         )
 
-    # We need a new state not already used
-    outside = object()
+    outside = _Outside.TOKEN
 
     # The set of strings that would be accepted by this FSM if you started
     # at state i is represented by the regex R_i.

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -3,6 +3,8 @@
     need to be in the same source file?
 '''
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Union
 

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Union
 
 from .fsm import Fsm, ANYTHING_ELSE, null, epsilon, alphabet_key
 from .multiplier import Multiplier, ZERO, QM, ONE, STAR
@@ -766,7 +765,7 @@ class Mult:
 
         e.g. a, b{2}, c?, d*, [efg]{2,5}, f{2,}, (anysubpattern)+, .*, ...
     '''
-    multiplicand: Union[Charclass, Pattern]
+    multiplicand: Charclass | Pattern
     multiplier: Multiplier
 
     def __eq__(self, other):

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -324,9 +324,9 @@ def from_fsm(f: Fsm):
         for symbol in f.map[a]:
             b = f.map[a][symbol]
             if symbol == ANYTHING_ELSE:
-                charclass = ~Charclass(f.alphabet - {ANYTHING_ELSE})
+                charclass = ~Charclass(frozenset(f.alphabet) - {ANYTHING_ELSE})
             else:
-                charclass = Charclass({symbol})
+                charclass = Charclass(frozenset((symbol,)))
 
             brz[a][b] = Pattern(
                 *brz[a][b].concs,

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum, auto
 
-from .fsm import Fsm, ANYTHING_ELSE, null, epsilon, alphabet_key
+from .fsm import Fsm, ANYTHING_ELSE, null, epsilon, alphabet_key, state_type
 from .multiplier import Multiplier, ZERO, QM, ONE, STAR
 from .charclass import Charclass, NULLCHARCLASS
 from .bound import Bound, INF
@@ -315,7 +315,8 @@ def from_fsm(f: Fsm):
         i += 1
 
     # Our system of equations is represented like so:
-    brz = {}
+    brz: dict[state_type, dict[state_type | _Outside, Pattern]] = {}
+
     for a in f.states:
         brz[a] = {}
         for b in f.states:

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
+import pickle
+import time
+
+import pytest
+
+from .charclass import DIGIT, WORDCHAR
+from .fsm import ANYTHING_ELSE, Fsm
+from .parse import parse
+from .rxelems import from_fsm
+
 if __name__ == "__main__":
     raise Exception(
         "Test files can't be run directly. Use `python -m pytest greenery`"
     )
-
-import pickle
-import pytest
-
-from .fsm import Fsm, ANYTHING_ELSE
-from .rxelems import from_fsm
-from .charclass import DIGIT, WORDCHAR
-from .parse import parse
 
 
 ###############################################################################
@@ -930,7 +932,6 @@ def test_isdisjoint():
 
 def test_bug_slow():
     # issue #43
-    import time
     m = Fsm(
         alphabet={'R', 'L', 'U', 'D'},
         states={

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 if __name__ == "__main__":
     raise Exception(
         "Test files can't be run directly. Use `python -m pytest greenery`"

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 if __name__ == "__main__":
     raise Exception(
         "Test files can't be run directly. Use `python -m pytest greenery`"

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from greenery import Bound, INF, Multiplier, PLUS, QM, STAR, parse
 
 pattern = parse("a")

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from greenery import Bound, INF, Multiplier, PLUS, QM, STAR, parse
+from greenery import INF, PLUS, QM, STAR, Bound, Multiplier, parse
 
 pattern = parse("a")
 print(pattern)  # "a"

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,13 @@
+[mypy]
+python_version = 3.8
+warn_return_any = True
+warn_unused_configs = True
+no_implicit_optional = True
+
+# strict typing
+strict_optional = True
+disallow_untyped_calls = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+check_untyped_defs = False
+disallow_untyped_decorators = True

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import setup
 
 setup(


### PR DESCRIPTION
This adds a very-lenient `mypy.ini` and adds `mypy` to the CI check steps.

It also fixes the bare-minimum of type errors necessary to pass initially, and modernizes the few type annotations present.

Since most of the code is unannotated, type-checking is skipped for most of it, hence the leniency.

(I also have this codebase checkable in full-coverage strict mode, but have some experiments to untangle from those branches).

This is based on the same base as #73, since the `from __future__ import annotations` allows the annotations to be more reasonable.