### PR TITLE
fsm: restore type-distinguished `ANYTHING_ELSE`

### DIFF
--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -4,11 +4,12 @@
     Finite state machine library, intended to be used by `greenery` only
 '''
 
-from typing import Optional, Union, Set, Dict
+from enum import Enum, auto
+from typing import Any, Optional, Union, Set, Dict
 from dataclasses import dataclass
 
 
-class AnythingElse:
+class AnythingElse(Enum):
     '''
         This is a surrogate symbol which you can use in your finite state
         machines to represent "any symbol not in the official alphabet". For
@@ -16,7 +17,19 @@ class AnythingElse:
         fsm.ANYTHING_ELSE}`, then if "e" is passed as a symbol, it will be
         converted to `fsm.ANYTHING_ELSE` before following the appropriate
         transition.
+
+        This is an `Enum` to enforce a singleton value, detectable by type
+        checkers, as described in:
+        https://www.python.org/dev/peps/pep-0484/#support-for-singleton-types-in-unions
     '''
+
+    TOKEN = auto()
+
+    def __eq__(self, other: Any, /) -> bool:
+        return self is other
+
+    def __hash__(self, /) -> int:
+        return hash(type(self))
 
     def __str__(self, /) -> str:
         return 'ANYTHING_ELSE'
@@ -25,7 +38,7 @@ class AnythingElse:
         return 'ANYTHING_ELSE'
 
 
-ANYTHING_ELSE = AnythingElse()
+ANYTHING_ELSE = AnythingElse.TOKEN
 
 
 def alphabet_key(symbol):

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -5,10 +5,12 @@
 '''
 
 from enum import Enum, auto
+from functools import total_ordering
 from typing import Any, Optional, Union, Set, Dict
 from dataclasses import dataclass
 
 
+@total_ordering
 class AnythingElse(Enum):
     '''
         This is a surrogate symbol which you can use in your finite state
@@ -25,6 +27,10 @@ class AnythingElse(Enum):
 
     TOKEN = auto()
 
+    def __lt__(self, _: Any, /) -> bool:
+        '''Ensure `fsm.ANYTHING_ELSE` always sorts last'''
+        return False
+
     def __eq__(self, other: Any, /) -> bool:
         return self is other
 
@@ -39,11 +45,6 @@ class AnythingElse(Enum):
 
 
 ANYTHING_ELSE = AnythingElse.TOKEN
-
-
-def alphabet_key(symbol):
-    '''Ensure `ANYTHING_ELSE` always sorts last'''
-    return (symbol is ANYTHING_ELSE, symbol)
 
 
 class OblivionError(Exception):
@@ -178,7 +179,7 @@ class Fsm:
     def __str__(self):
         rows = []
 
-        sorted_alphabet = sorted(self.alphabet, key=alphabet_key)
+        sorted_alphabet = sorted(self.alphabet)
 
         # top row
         row = ["", "name", "final?"]
@@ -554,7 +555,7 @@ class Fsm:
         while i < len(strings):
             (cstring, cstate) = strings[i]
             if cstate in self.map:
-                for symbol in sorted(self.map[cstate], key=alphabet_key):
+                for symbol in sorted(self.map[cstate]):
                     nstate = self.map[cstate][symbol]
                     nstring = cstring + [symbol]
                     if nstate in livestates:
@@ -863,7 +864,7 @@ def crawl(alphabet, initial, final, follow):
 
         # compute map for this state
         map[i] = {}
-        for symbol in sorted(alphabet, key=alphabet_key):
+        for symbol in sorted(alphabet):
             try:
                 next = follow(state, symbol)
 

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -7,7 +7,25 @@
 from typing import Optional, Union, Set, Dict
 from dataclasses import dataclass
 
-ANYTHING_ELSE = '9bd74361-04f9-4742-9d3a-1d14a6f0044c'
+
+class AnythingElse:
+    '''
+        This is a surrogate symbol which you can use in your finite state
+        machines to represent "any symbol not in the official alphabet". For
+        example, if your state machine's alphabet is `{"a", "b", "c", "d",
+        fsm.ANYTHING_ELSE}`, then if "e" is passed as a symbol, it will be
+        converted to `fsm.ANYTHING_ELSE` before following the appropriate
+        transition.
+    '''
+
+    def __str__(self, /) -> str:
+        return 'ANYTHING_ELSE'
+
+    def __repr__(self, /) -> str:
+        return 'ANYTHING_ELSE'
+
+
+ANYTHING_ELSE = AnythingElse()
 
 
 def alphabet_key(symbol):
@@ -26,7 +44,7 @@ class OblivionError(Exception):
     pass
 
 
-alpha_type = str
+alpha_type = Union[str, AnythingElse]
 
 
 state_type = Optional[Union[int, str]]
@@ -151,10 +169,7 @@ class Fsm:
 
         # top row
         row = ["", "name", "final?"]
-        row.extend(
-          'ANYTHING_ELSE' if symbol is ANYTHING_ELSE else str(symbol)
-          for symbol in sorted_alphabet
-        )
+        row.extend(str(symbol) for symbol in sorted_alphabet)
         rows.append(row)
 
         # other rows

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -26,6 +26,9 @@ class OblivionError(Exception):
     pass
 
 
+alpha_type = str
+
+
 state_type = Optional[Union[int, str]]
 
 
@@ -46,9 +49,9 @@ class Fsm:
     '''
     initial: state_type
     finals: Set[state_type]
-    alphabet: Set[str]
+    alphabet: Set[alpha_type]
     states: Set[state_type]
-    map: Dict[state_type, Dict[str, state_type]]
+    map: Dict[state_type, Dict[alpha_type, state_type]]
 
     def __post_init__(self):
         '''

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -4,7 +4,7 @@ import pickle
 
 import pytest
 
-from .fsm import Fsm, null, epsilon, ANYTHING_ELSE, AnythingElse, alphabet_key
+from .fsm import Fsm, null, epsilon, ANYTHING_ELSE, AnythingElse
 
 
 def test_addbug():
@@ -789,6 +789,50 @@ def test_anything_else_singleton():
     assert AnythingElse.TOKEN is ANYTHING_ELSE
 
 
+def test_anything_else_self():
+    """ANYTHING_ELSE is consistently equal to itself."""
+
+    # pylint: disable=comparison-with-itself
+    # pylint: disable=unneeded-not
+    assert not ANYTHING_ELSE < ANYTHING_ELSE
+    assert ANYTHING_ELSE <= ANYTHING_ELSE
+    assert not ANYTHING_ELSE != ANYTHING_ELSE
+    assert ANYTHING_ELSE == ANYTHING_ELSE
+    assert ANYTHING_ELSE >= ANYTHING_ELSE
+    assert not ANYTHING_ELSE > ANYTHING_ELSE
+
+
+@pytest.mark.parametrize(
+    argnames="val",
+    argvalues=(
+        float("-inf"),
+        float("nan"),
+        float("inf"),
+        0,
+        "abc",
+        object(),
+        str(ANYTHING_ELSE),
+    ),
+)
+def test_anything_else_sorts_after(val):
+    """ANYTHING_ELSE sorts strictly after anything."""
+
+    # pylint: disable=unneeded-not
+    assert not ANYTHING_ELSE < val
+    assert not ANYTHING_ELSE <= val
+    assert not ANYTHING_ELSE == val
+    assert ANYTHING_ELSE != val
+    assert ANYTHING_ELSE > val
+    assert ANYTHING_ELSE >= val
+
+    assert val < ANYTHING_ELSE
+    assert val <= ANYTHING_ELSE
+    assert val != ANYTHING_ELSE
+    assert not val == ANYTHING_ELSE
+    assert not val > ANYTHING_ELSE
+    assert not val >= ANYTHING_ELSE
+
+
 def test_anything_else_pickle():
     # [^z]
     fsm1 = Fsm(
@@ -808,7 +852,7 @@ def test_anything_else_pickle():
     assert fsm1 == fsm1_unpickled
 
     # The first letter is "z" (since "anything else" always sorts last).
-    letter_z, anything_else = sorted(fsm1_unpickled.alphabet, key=alphabet_key)
+    letter_z, anything_else = sorted(fsm1_unpickled.alphabet)
     assert letter_z == "z"
 
     # Stronger singleton assertion:

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
+import pickle
+
 import pytest
 
-from .fsm import Fsm, null, epsilon, ANYTHING_ELSE
+from .fsm import Fsm, null, epsilon, ANYTHING_ELSE, AnythingElse, alphabet_key
 
 
 def test_addbug():
@@ -781,3 +783,33 @@ def test_add_anything_else():
         map={0: {ANYTHING_ELSE: 1}}
     )
     assert (fsm1 + fsm2).accepts("ba")
+
+
+def test_anything_else_singleton():
+    assert AnythingElse.TOKEN is ANYTHING_ELSE
+
+
+def test_anything_else_pickle():
+    # [^z]
+    fsm1 = Fsm(
+        alphabet={"z", ANYTHING_ELSE},
+        states={0, 1},
+        initial=0,
+        finals={1},
+        map={0: {ANYTHING_ELSE: 1}}
+    )
+
+    fsm1_unpickled = pickle.loads(pickle.dumps(fsm1))
+
+    # Newly-created instance.
+    assert fsm1_unpickled is not fsm1
+
+    # but equivalent.
+    assert fsm1 == fsm1_unpickled
+
+    # The first letter is "z" (since "anything else" always sorts last).
+    letter_z, anything_else = sorted(fsm1_unpickled.alphabet, key=alphabet_key)
+    assert letter_z == "z"
+
+    # Stronger singleton assertion:
+    assert anything_else is ANYTHING_ELSE

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -8,7 +8,7 @@
 from dataclasses import dataclass
 from typing import Union
 
-from .fsm import Fsm, ANYTHING_ELSE, null, epsilon, alphabet_key
+from .fsm import Fsm, ANYTHING_ELSE, null, epsilon
 from .multiplier import Multiplier, ZERO, QM, ONE, STAR
 from .charclass import Charclass, NULLCHARCLASS
 from .bound import Bound, INF
@@ -299,7 +299,7 @@ def from_fsm(f: Fsm):
     while i < len(states):
         current = states[i]
         if current in f.map:
-            for symbol in sorted(f.map[current], key=alphabet_key):
+            for symbol in sorted(f.map[current]):
                 next = f.map[current][symbol]
                 if next not in states:
                     states.append(next)

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -268,7 +268,7 @@ def from_fsm(f: Fsm):
     # Make sure the supplied alphabet is kosher. It must contain only single-
     # character strings or `ANYTHING_ELSE`.
     for symbol in f.alphabet:
-        if symbol == ANYTHING_ELSE:
+        if symbol is ANYTHING_ELSE:
             continue
         if isinstance(symbol, str) and len(symbol) == 1:
             continue
@@ -321,7 +321,7 @@ def from_fsm(f: Fsm):
     for a in f.map:
         for symbol in f.map[a]:
             b = f.map[a][symbol]
-            if symbol == ANYTHING_ELSE:
+            if symbol is ANYTHING_ELSE:
                 charclass = ~Charclass(f.alphabet - {ANYTHING_ELSE})
             else:
                 charclass = Charclass({symbol})
@@ -741,7 +741,7 @@ class Pattern:
                 if otherchar is None:
                     raise Exception("Please choose an `otherchar`")
                 string = [
-                    otherchar if char == ANYTHING_ELSE else char
+                    otherchar if char is ANYTHING_ELSE else char
                     for char in string
                 ]
 


### PR DESCRIPTION
In greenery v4, `anything_else` was just an instance of a single-use eponymous class.

In #65, it was changed to a fixed random string to address #64

However, that symbol is _not_ a string: it's a special symbol and has special comparison characteristics. It kinda represents the "co-alphabet".

This re-introduces the class instance, but modernizes it and keeps that original bug fixed.
  * It's made a singleton enum. This allows type-checkers to automatically refine checks like `if x is ANYTHING_ELSE` without needing casts or `isinstance` checks. It also ensures that unplicking does not make a separate instance.
  * The comparison operators are updated to incorporate its special comparison behaviour, eliminating the need to carry an `alphabet_key` helper around.
  * Some tests are added to verify its round-trip pickling behaviour.