### PR TITLE
mypy: enable strict mode using per-file suppression

### DIFF
--- a/greenery/bound.py
+++ b/greenery/bound.py
@@ -7,6 +7,8 @@ __all__ = (
 
 from dataclasses import dataclass
 
+# mypy: allow-untyped-defs
+
 
 @dataclass(frozen=True)
 class Bound:

--- a/greenery/bound_test.py
+++ b/greenery/bound_test.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from .bound import INF, Bound
 
+# mypy: allow-untyped-defs
+
 
 def test_bound_str():
     assert str(Bound(2)) == "2"

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -18,6 +18,11 @@ from dataclasses import dataclass
 
 from .fsm import ANYTHING_ELSE, Fsm
 
+# This class currently has broken types due to its "frozenset[str] | str" member.
+# mypy: allow-untyped-calls
+# mypy: allow-untyped-defs
+# mypy: no-check-untyped-defs
+
 
 @dataclass(frozen=True)
 class Charclass:

--- a/greenery/charclass_test.py
+++ b/greenery/charclass_test.py
@@ -13,6 +13,9 @@ from .charclass import (
 )
 from .fsm import ANYTHING_ELSE
 
+# mypy: allow-untyped-calls
+# mypy: allow-untyped-defs
+
 
 def test_charclass_equality():
     assert Charclass("a") == Charclass("a")

--- a/greenery/conc_test.py
+++ b/greenery/conc_test.py
@@ -7,6 +7,9 @@ from .charclass import Charclass
 from .multiplier import ONE, PLUS, QM, STAR, ZERO, Multiplier
 from .rxelems import Conc, Mult
 
+# mypy: allow-untyped-calls
+# mypy: allow-untyped-defs
+
 
 def test_conc_equality():
     a = Conc(Mult(Charclass("a"), ONE))

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -18,6 +18,11 @@ from enum import Enum, auto
 from functools import total_ordering
 from typing import Any, Union
 
+# mypy: allow-incomplete-defs
+# mypy: allow-untyped-calls
+# mypy: allow-untyped-defs
+# mypy: no-check-untyped-defs
+
 
 @total_ordering
 class AnythingElse(Enum):

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -6,6 +6,10 @@ import pytest
 
 from .fsm import ANYTHING_ELSE, AnythingElse, Fsm, epsilon, null
 
+# mypy: allow-untyped-calls
+# mypy: allow-untyped-defs
+# mypy: no-check-untyped-defs
+
 
 def test_addbug():
     # Odd bug with Fsm.__add__(), exposed by "[bc]*c"

--- a/greenery/mult_test.py
+++ b/greenery/mult_test.py
@@ -6,6 +6,9 @@ from .fsm import ANYTHING_ELSE
 from .multiplier import ONE, PLUS, QM, STAR, Multiplier
 from .rxelems import Mult
 
+# mypy: allow-untyped-calls
+# mypy: allow-untyped-defs
+
 
 def test_mult_equality():
     a = Mult(Charclass("a"), ONE)

--- a/greenery/multiplier.py
+++ b/greenery/multiplier.py
@@ -14,6 +14,9 @@ from dataclasses import dataclass, field
 
 from .bound import INF, Bound
 
+# mypy: allow-untyped-calls
+# mypy: allow-untyped-defs
+
 
 @dataclass(frozen=True)
 class Multiplier:

--- a/greenery/multiplier_test.py
+++ b/greenery/multiplier_test.py
@@ -5,6 +5,9 @@ import pytest
 from .bound import INF, Bound
 from .multiplier import ONE, PLUS, QM, STAR, ZERO, Multiplier
 
+# mypy: allow-untyped-calls
+# mypy: allow-untyped-defs
+
 
 def test_multiplier_str():
     assert str(Multiplier(Bound(2), INF)) == "{2,}"

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -10,6 +10,10 @@ from .charclass import Charclass, escapes, shorthand
 from .multiplier import Multiplier, symbolic
 from .rxelems import Conc, Mult, Pattern
 
+# mypy: allow-untyped-calls
+# mypy: allow-untyped-defs
+# mypy: allow-incomplete-defs
+
 
 class NoMatch(Exception):
     '''

--- a/greenery/parse_test.py
+++ b/greenery/parse_test.py
@@ -10,6 +10,9 @@ from .multiplier import ONE, PLUS, STAR, Multiplier
 from .parse import NoMatch, match_charclass, match_mult, parse
 from .rxelems import Conc, Mult, Pattern
 
+# mypy: allow-untyped-calls
+# mypy: allow-untyped-defs
+
 if __name__ == "__main__":
     raise Exception(
         "Test files can't be run directly. Use `python -m pytest greenery`"

--- a/greenery/pattern_test.py
+++ b/greenery/pattern_test.py
@@ -5,6 +5,9 @@ from .multiplier import ONE, ZERO
 from .parse import parse
 from .rxelems import Conc, Mult, Pattern
 
+# mypy: allow-untyped-calls
+# mypy: allow-untyped-defs
+
 
 def test_pattern_equality():
     assert Pattern(

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -21,6 +21,10 @@ from .charclass import NULLCHARCLASS, Charclass
 from .fsm import ANYTHING_ELSE, Fsm, epsilon, null, state_type
 from .multiplier import ONE, QM, STAR, ZERO, Multiplier
 
+# mypy: allow-untyped-calls
+# mypy: allow-untyped-defs
+# mypy: no-check-untyped-defs
+
 
 @dataclass(frozen=True)
 class Conc():

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -10,6 +10,10 @@ from .fsm import ANYTHING_ELSE, Fsm
 from .parse import parse
 from .rxelems import from_fsm
 
+# mypy: allow-untyped-calls
+# mypy: allow-untyped-defs
+# mypy: no-check-untyped-defs
+
 if __name__ == "__main__":
     raise Exception(
         "Test files can't be run directly. Use `python -m pytest greenery`"

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,8 +6,16 @@ no_implicit_optional = True
 
 # strict typing
 strict_optional = True
-disallow_untyped_calls = False
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-check_untyped_defs = False
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
 disallow_untyped_decorators = True
+
+disallow_any_generics = True
+disallow_subclassing_any = True
+no_implicit_reexport = True
+strict_concatenate = True
+strict_equality = True
+warn_redundant_casts = True
+warn_unused_ignores = True


### PR DESCRIPTION
This turns on all the checking of mypy overall; and then for each file it adds the necessary suppressions. Very heavy-handed, but allows type fixes to be applied independently.