### PR TITLE
dev: improve `.editorconfig`, add `.vscode`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,16 @@
+root = true
+
 [*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 [*.py]
-charset = utf-8
-indent_style = space
 indent_size = 4
+max_line_length = 80
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "ms-python.isort",
+    "ms-python.python"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2,
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "files.trimTrailingWhitespace": true,
+  "isort.check": true,
+  "python.analysis.importFormat": "relative",
+  "python.linting.flake8Enabled": true,
+  "python.linting.mypyEnabled": true,
+  "python.testing.pytestEnabled": true,
+  "[python]": {
+    "editor.tabSize": 4,
+    "vim.textwidth": 80
+  }
+}


### PR DESCRIPTION
This extends the `.editorconfig` to set `root = True`, include the `max_line_length`, and differentiate the defaults for `.py` files vs. everything else. (`.md`, `.ini`, `.yaml`, etc which tend to use indent=4).

It also adds `.vscode`, recommending the main python extension + isort + mypy + pytest, and editing defaults compatible with the current flake8 + editorconfig settings.