### PR TITLE
lint: fix up strict-ish flake8/pycodestyle formatting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 80

--- a/.flake8
+++ b/.flake8
@@ -3,5 +3,3 @@ max-line-length = 80
 ignore =
   # line break before binary operator
   W503,
-  # line break after binary operator
-  W504,

--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,6 @@
 [flake8]
 max-line-length = 80
 ignore =
-  # continuation line over-indented for hanging indent
-  E126,
   # missing whitespace around arithmetic operator
   E226,
   # line break before binary operator

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,13 @@
 [flake8]
 max-line-length = 80
+ignore =
+  # continuation line under-indented for hanging indent
+  E121,
+  # continuation line over-indented for hanging indent
+  E126,
+  # missing whitespace around arithmetic operator
+  E226,
+  # line break before binary operator
+  W503,
+  # line break after binary operator
+  W504,

--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,6 @@
 [flake8]
 max-line-length = 80
 ignore =
-  # continuation line under-indented for hanging indent
-  E121,
   # continuation line over-indented for hanging indent
   E126,
   # missing whitespace around arithmetic operator

--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,6 @@
 [flake8]
 max-line-length = 80
 ignore =
-  # missing whitespace around arithmetic operator
-  E226,
   # line break before binary operator
   W503,
   # line break after binary operator

--- a/.github/workflows/workflow-1.yml
+++ b/.github/workflows/workflow-1.yml
@@ -32,7 +32,7 @@ jobs:
         # stop the build if there are Python syntax errors or undefined names
         flake8 --count --statistics --show-source --select=E9,F63,F7,F82 .
         # exit-zero treats all errors as warnings
-        flake8 --count --statistics --exit-zero --max-line-length=80 .
+        flake8 --count --statistics --exit-zero .
     - name: Check with mypy
       run: |
         mypy greenery

--- a/.github/workflows/workflow-1.yml
+++ b/.github/workflows/workflow-1.yml
@@ -30,9 +30,9 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 --count --statistics --show-source --select=E9,F63,F7,F82 .
         # exit-zero treats all errors as warnings
-        flake8 . --count --exit-zero --max-line-length=80 --statistics
+        flake8 --count --statistics --exit-zero --max-line-length=80 .
     - name: Check with mypy
       run: |
         mypy greenery

--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ Special `Bound` representing no limit. Can be used as an upper bound only.
 ```sh
 isort .
 mypy greenery
-flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-flake8 . --count --exit-zero --max-complexity=10 --max-line-length=80 --statistics
+flake8 --count --statistics --show-source --select=E9,F63,F7,F82 .
+flake8 --count --statistics --exit-zero --max-complexity=10 --max-line-length=80 .
 pytest
 ```
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Special `Bound` representing no limit. Can be used as an upper bound only.
 isort .
 mypy greenery
 flake8 --count --statistics --show-source --select=E9,F63,F7,F82 .
-flake8 --count --statistics --exit-zero --max-complexity=10 --max-line-length=80 .
+flake8 --count --statistics --exit-zero --max-complexity=10 .
 pytest
 ```
 

--- a/greenery/bound.py
+++ b/greenery/bound.py
@@ -59,8 +59,8 @@ class Bound:
 
     def __sub__(self, other):
         '''
-            Subtract another bound from this one.
-            Caution: this operation is not meaningful for all bounds.
+        Subtract another bound from this one.
+        Caution: this operation is not meaningful for all bounds.
         '''
         if other == INF:
             if self != INF:

--- a/greenery/bound.py
+++ b/greenery/bound.py
@@ -16,10 +16,10 @@ class Bound:
 
     def __post_init__(self):
         if self.v is not None and self.v < 0:
-            raise Exception(f"Invalid bound: {repr(self.v)}")
+            raise Exception(f"Invalid bound: {self.v!r}")
 
     def __repr__(self):
-        return f"Bound({repr(self.v)})"
+        return f"Bound({self.v!r})"
 
     def __str__(self):
         if self == INF:
@@ -65,7 +65,7 @@ class Bound:
         if other == INF:
             if self != INF:
                 raise Exception(
-                    f"Can't subtract {repr(other)} from {repr(self)}"
+                    f"Can't subtract {other!r} from {self!r}"
                 )
 
             # Infinity minus infinity is zero. This has to be true so that

--- a/greenery/bound.py
+++ b/greenery/bound.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class Bound:
     '''An integer but sometimes also possibly infinite (None)'''
+
     v: int | None
 
     def __post_init__(self):

--- a/greenery/bound.py
+++ b/greenery/bound.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class Bound:
-    '''An integer but sometimes also possibly infinite (None)'''
+    """An integer but sometimes also possibly infinite (None)"""
 
     v: int | None
 
@@ -44,7 +44,7 @@ class Bound:
         return not self < other
 
     def __mul__(self, other):
-        '''Multiply this bound by another'''
+        """Multiply this bound by another"""
         if self == Bound(0) or other == Bound(0):
             return Bound(0)
         if self == INF or other == INF:
@@ -52,16 +52,16 @@ class Bound:
         return Bound(self.v * other.v)
 
     def __add__(self, other):
-        '''Add this bound to another'''
+        """Add this bound to another"""
         if self == INF or other == INF:
             return INF
         return Bound(self.v + other.v)
 
     def __sub__(self, other):
-        '''
+        """
         Subtract another bound from this one.
         Caution: this operation is not meaningful for all bounds.
-        '''
+        """
         if other == INF:
             if self != INF:
                 raise Exception(

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -135,9 +135,9 @@ class Charclass:
                 "".join(escapeChar(char) for char in currentRange),
                 # "a-b" or "a-c" or "a-d"
                 (
-                    escapeChar(currentRange[0]) +
-                    "-" +
-                    escapeChar(currentRange[-1])
+                    escapeChar(currentRange[0])
+                    + "-"
+                    + escapeChar(currentRange[-1])
                 ),
             ]
             return sorted(strs, key=lambda str: len(str))[0]

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -21,14 +21,14 @@ from .fsm import ANYTHING_ELSE, Fsm
 
 @dataclass(frozen=True)
 class Charclass:
-    '''
+    """
     A `Charclass` is basically a `frozenset` of symbols.
     A `Charclass` with the `negated` flag set is assumed
     to contain every symbol that is in the alphabet of all symbols but not
     explicitly listed inside the frozenset. e.g. [^a]. This is very handy
     if the full alphabet is extremely large, but also requires dedicated
     combination functions.
-    '''
+    """
 
     chars: frozenset[str] | str
     negated: bool = False
@@ -219,10 +219,10 @@ class Charclass:
 
     # set operations
     def negate(self):
-        '''
+        """
         Negate the current `Charclass`. e.g. [ab] becomes [^ab]. Call
         using "charclass2 = ~charclass1"
-        '''
+        """
         return Charclass(self.chars, negated=not self.negated)
 
     def __invert__(self):

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -38,7 +38,7 @@ class Charclass:
         # chars should consist only of chars
         if ANYTHING_ELSE in self.chars:
             raise Exception(
-                f"Can't put {repr(ANYTHING_ELSE)} in a `Charclass`"
+                f"Can't put {ANYTHING_ELSE!r} in a `Charclass`"
             )
 
     def __eq__(self, other):

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -22,12 +22,12 @@ from .fsm import ANYTHING_ELSE, Fsm
 @dataclass(frozen=True)
 class Charclass:
     '''
-        A `Charclass` is basically a `frozenset` of symbols.
-        A `Charclass` with the `negated` flag set is assumed
-        to contain every symbol that is in the alphabet of all symbols but not
-        explicitly listed inside the frozenset. e.g. [^a]. This is very handy
-        if the full alphabet is extremely large, but also requires dedicated
-        combination functions.
+    A `Charclass` is basically a `frozenset` of symbols.
+    A `Charclass` with the `negated` flag set is assumed
+    to contain every symbol that is in the alphabet of all symbols but not
+    explicitly listed inside the frozenset. e.g. [^a]. This is very handy
+    if the full alphabet is extremely large, but also requires dedicated
+    combination functions.
     '''
 
     chars: frozenset[str] | str
@@ -220,8 +220,8 @@ class Charclass:
     # set operations
     def negate(self):
         '''
-            Negate the current `Charclass`. e.g. [ab] becomes [^ab]. Call
-            using "charclass2 = ~charclass1"
+        Negate the current `Charclass`. e.g. [ab] becomes [^ab]. Call
+        using "charclass2 = ~charclass1"
         '''
         return Charclass(self.chars, negated=not self.negated)
 

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -104,7 +104,7 @@ class Charclass:
             # If char is an ASCII control character, don't print it directly,
             # return a hex escape sequence e.g. "\\x00". Note that this
             # includes tab and other characters already handled above
-            if 0 <= ord(char) <= 0x1F or ord(char) == 0x7f:
+            if 0 <= ord(char) <= 0x1F or ord(char) == 0x7F:
                 return "\\x" + "{0:02x}".format(ord(char))
 
             return char
@@ -122,7 +122,7 @@ class Charclass:
             # If char is an ASCII control character, don't print it directly,
             # return a hex escape sequence e.g. "\\x00". Note that this
             # includes tab and other characters already handled above
-            if 0 <= ord(char) <= 0x1F or ord(char) == 0x7f:
+            if 0 <= ord(char) <= 0x1F or ord(char) == 0x7F:
                 return "\\x" + "{0:02x}".format(ord(char))
 
             return char

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -43,8 +43,8 @@ class Charclass:
 
     def __eq__(self, other):
         return isinstance(other, Charclass) \
-               and self.chars == other.chars \
-               and self.negated == other.negated
+            and self.chars == other.chars \
+            and self.negated == other.negated
 
     def __hash__(self):
         return hash((self.chars, self.negated))

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -29,6 +29,7 @@ class Charclass:
         if the full alphabet is extremely large, but also requires dedicated
         combination functions.
     '''
+
     chars: frozenset[str] | str
     negated: bool = False
 

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -110,29 +110,29 @@ class Fsm:
         # once.
         if self.initial not in self.states:
             raise Exception(
-                f"Initial state {repr(self.initial)}"
-                f" must be one of {repr(self.states)}"
+                f"Initial state {self.initial!r}"
+                f" must be one of {self.states!r}"
             )
         if not self.finals.issubset(self.states):
             raise Exception(
-                f"Final states {repr(self.finals)}"
-                f" must be a subset of {repr(self.states)}"
+                f"Final states {self.finals!r}"
+                f" must be a subset of {self.states!r}"
             )
         for state, _state_trans in self.map.items():
             if state not in self.states:
-                raise Exception(f"Transition from unknown state {repr(state)}")
+                raise Exception(f"Transition from unknown state {state!r}")
             for symbol in self.map[state]:
                 if symbol not in self.alphabet:
                     raise Exception(
-                        f"Invalid symbol {repr(symbol)}"
-                        f" in transition from {repr(state)}"
-                        f" to {repr(self.map[state][symbol])}"
+                        f"Invalid symbol {symbol!r}"
+                        f" in transition from {state!r}"
+                        f" to {self.map[state][symbol]!r}"
                     )
                 if not self.map[state][symbol] in self.states:
                     raise Exception(
-                        f"Transition for state {repr(state)}"
-                        f" and symbol {repr(symbol)}"
-                        f" leads to {repr(self.map[state][symbol])},"
+                        f"Transition for state {state!r}"
+                        f" and symbol {symbol!r}"
+                        f" leads to {self.map[state][symbol]!r},"
                         " which is not a state"
                     )
 
@@ -179,11 +179,11 @@ class Fsm:
 
     def __repr__(self):
         args = ", ".join([
-            f"alphabet={repr(self.alphabet)}",
-            f"states={repr(self.states)}",
-            f"initial={repr(self.initial)}",
-            f"finals={repr(self.finals)}",
-            f"map={repr(self.map)}",
+            f"alphabet={self.alphabet!r}",
+            f"states={self.states!r}",
+            f"initial={self.initial!r}",
+            f"finals={self.finals!r}",
+            f"map={self.map!r}",
         ])
         return f"Fsm({args})"
 
@@ -344,7 +344,7 @@ class Fsm:
         Given an FSM and a multiplier, return the multiplied FSM.
         """
         if multiplier < 0:
-            raise Exception(f"Can't multiply an FSM by {repr(multiplier)}")
+            raise Exception(f"Can't multiply an FSM by {multiplier!r}")
 
         alphabet = self.alphabet
 

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -110,13 +110,13 @@ class Fsm:
         # once.
         if self.initial not in self.states:
             raise Exception(
-                f"Initial state {repr(self.initial)} "
-                f"must be one of {repr(self.states)}"
+                f"Initial state {repr(self.initial)}"
+                f" must be one of {repr(self.states)}"
             )
         if not self.finals.issubset(self.states):
             raise Exception(
-                f"Final states {repr(self.finals)} "
-                f"must be a subset of {repr(self.states)}"
+                f"Final states {repr(self.finals)}"
+                f" must be a subset of {repr(self.states)}"
             )
         for state, _state_trans in self.map.items():
             if state not in self.states:
@@ -124,16 +124,16 @@ class Fsm:
             for symbol in self.map[state]:
                 if symbol not in self.alphabet:
                     raise Exception(
-                        f"Invalid symbol {repr(symbol)} "
-                        f"in transition from {repr(state)} "
-                        f"to {repr(self.map[state][symbol])}"
+                        f"Invalid symbol {repr(symbol)}"
+                        f" in transition from {repr(state)}"
+                        f" to {repr(self.map[state][symbol])}"
                     )
                 if not self.map[state][symbol] in self.states:
                     raise Exception(
-                        f"Transition for state {repr(state)} "
-                        f"and symbol {repr(symbol)} "
-                        f"leads to {repr(self.map[state][symbol])}, "
-                        "which is not a state"
+                        f"Transition for state {repr(state)}"
+                        f" and symbol {repr(symbol)}"
+                        f" leads to {repr(self.map[state][symbol])},"
+                        " which is not a state"
                     )
 
         # Initialise the hard way due to immutability.

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -1,5 +1,5 @@
 '''
-    Finite state machine library, intended to be used by `greenery` only
+Finite state machine library, intended to be used by `greenery` only
 '''
 
 from __future__ import annotations
@@ -22,16 +22,16 @@ from typing import Any, Union
 @total_ordering
 class AnythingElse(Enum):
     '''
-        This is a surrogate symbol which you can use in your finite state
-        machines to represent "any symbol not in the official alphabet". For
-        example, if your state machine's alphabet is `{"a", "b", "c", "d",
-        fsm.ANYTHING_ELSE}`, then if "e" is passed as a symbol, it will be
-        converted to `fsm.ANYTHING_ELSE` before following the appropriate
-        transition.
+    This is a surrogate symbol which you can use in your finite state
+    machines to represent "any symbol not in the official alphabet". For
+    example, if your state machine's alphabet is `{"a", "b", "c", "d",
+    fsm.ANYTHING_ELSE}`, then if "e" is passed as a symbol, it will be
+    converted to `fsm.ANYTHING_ELSE` before following the appropriate
+    transition.
 
-        This is an `Enum` to enforce a singleton value, detectable by type
-        checkers, as described in:
-        https://www.python.org/dev/peps/pep-0484/#support-for-singleton-types-in-unions
+    This is an `Enum` to enforce a singleton value, detectable by type
+    checkers, as described in:
+    https://www.python.org/dev/peps/pep-0484/#support-for-singleton-types-in-unions
     '''
 
     TOKEN = auto()
@@ -58,11 +58,11 @@ ANYTHING_ELSE = AnythingElse.TOKEN
 
 class OblivionError(Exception):
     '''
-        This exception is thrown while `crawl()`ing an FSM if we transition to
-        the oblivion state. For example while crawling two FSMs in parallel we
-        may transition to the oblivion state of both FSMs at once. This
-        warrants an out-of-band signal which will reduce the complexity of the
-        new FSM's map.
+    This exception is thrown while `crawl()`ing an FSM if we transition to
+    the oblivion state. For example while crawling two FSMs in parallel we
+    may transition to the oblivion state of both FSMs at once. This
+    warrants an out-of-band signal which will reduce the complexity of the
+    new FSM's map.
     '''
 
     pass
@@ -77,17 +77,17 @@ state_type = Union[int, str, None]
 @dataclass(frozen=True)
 class Fsm:
     '''
-        A Finite State Machine or FSM has an alphabet and a set of states. At
-        any given moment, the FSM is in one state. When passed a symbol from
-        the alphabet, the FSM jumps to another state (or possibly the same
-        state). A map (Python dictionary) indicates where to jump.
-        One state is nominated as a starting state. Zero or more states are
-        nominated as final states. If, after consuming a string of symbols,
-        the FSM is in a final state, then it is said to "accept" the string.
-        This class also has some pretty powerful methods which allow FSMs to
-        be concatenated, alternated between, multiplied, looped (Kleene star
-        closure), intersected, and simplified.
-        The majority of these methods are available using operator overloads.
+    A Finite State Machine or FSM has an alphabet and a set of states. At
+    any given moment, the FSM is in one state. When passed a symbol from
+    the alphabet, the FSM jumps to another state (or possibly the same
+    state). A map (Python dictionary) indicates where to jump.
+    One state is nominated as a starting state. Zero or more states are
+    nominated as final states. If, after consuming a string of symbols,
+    the FSM is in a final state, then it is said to "accept" the string.
+    This class also has some pretty powerful methods which allow FSMs to
+    be concatenated, alternated between, multiplied, looped (Kleene star
+    closure), intersected, and simplified.
+    The majority of these methods are available using operator overloads.
     '''
 
     initial: state_type
@@ -98,12 +98,12 @@ class Fsm:
 
     def __post_init__(self):
         '''
-            `alphabet` is an iterable of symbols the FSM can be fed.
-            `states` is the set of states for the FSM
-            `initial` is the initial state
-            `finals` is the set of accepting states
-            `map` may be sparse (i.e. it may omit transitions). In the case of
-            omitted transitions, a non-final "oblivion" state is simulated.
+        `alphabet` is an iterable of symbols the FSM can be fed.
+        `states` is the set of states for the FSM
+        `initial` is the initial state
+        `finals` is the set of accepting states
+        `map` may be sparse (i.e. it may omit transitions). In the case of
+        omitted transitions, a non-final "oblivion" state is simulated.
         '''
 
         # Validation. Thanks to immutability, this only needs to be carried out
@@ -143,12 +143,12 @@ class Fsm:
 
     def accepts(self, input):
         '''
-            Test whether the present FSM accepts the supplied string (iterable
-            of symbols). Equivalently, consider `self` as a possibly-infinite
-            set of strings and test whether `string` is a member of it. This is
-            actually mainly used for unit testing purposes. If `ANYTHING_ELSE`
-            is in your alphabet, then any symbol not in your alphabet will be
-            converted to `ANYTHING_ELSE`.
+        Test whether the present FSM accepts the supplied string (iterable
+        of symbols). Equivalently, consider `self` as a possibly-infinite
+        set of strings and test whether `string` is a member of it. This is
+        actually mainly used for unit testing purposes. If `ANYTHING_ELSE`
+        is in your alphabet, then any symbol not in your alphabet will be
+        converted to `ANYTHING_ELSE`.
         '''
         state = self.initial
         for symbol in input:
@@ -164,16 +164,16 @@ class Fsm:
 
     def __contains__(self, string):
         '''
-            This lets you use the syntax `"a" in fsm1` to see whether the
-            string "a" is in the set of strings accepted by `fsm1`.
+        This lets you use the syntax `"a" in fsm1` to see whether the
+        string "a" is in the set of strings accepted by `fsm1`.
         '''
         return self.accepts(string)
 
     def reduce(self):
         '''
-            A result by Brzozowski (1963) shows that a minimal finite state
-            machine equivalent to the original can be obtained by reversing the
-            original twice.
+        A result by Brzozowski (1963) shows that a minimal finite state
+        machine equivalent to the original can be obtained by reversing the
+        original twice.
         '''
         return self.reversed().reversed()
 
@@ -235,16 +235,16 @@ class Fsm:
 
     def concatenate(*fsms):
         '''
-            Concatenate arbitrarily many finite state machines together.
+        Concatenate arbitrarily many finite state machines together.
         '''
         alphabet = set().union(*[fsm.alphabet for fsm in fsms])
 
         def connect_all(i, substate):
             '''
-                Take a state in the numbered FSM and return a set containing
-                it, plus (if it's final) the first state from the next FSM,
-                plus (if that's final) the first state from the next but one
-                FSM, plus...
+            Take a state in the numbered FSM and return a set containing
+            it, plus (if it's final) the first state from the next FSM,
+            plus (if that's final) the first state from the next but one
+            FSM, plus...
             '''
             result = {(i, substate)}
             while i < len(fsms) - 1 and substate in fsms[i].finals:
@@ -271,10 +271,10 @@ class Fsm:
 
         def follow(current, symbol):
             '''
-                Follow the collection of states through all FSMs at once,
-                jumping to the next FSM if we reach the end of the current one
-                TODO: improve all follow() implementations to allow for dead
-                metastates?
+            Follow the collection of states through all FSMs at once,
+            jumping to the next FSM if we reach the end of the current one
+            TODO: improve all follow() implementations to allow for dead
+            metastates?
             '''
             next = set()
             for (i, substate) in current:
@@ -298,19 +298,19 @@ class Fsm:
 
     def __add__(self, other):
         '''
-            Concatenate two finite state machines together.
-            For example, if self accepts "0*" and other accepts "1+(0|1)",
-            will return a finite state machine accepting "0*1+(0|1)".
-            Accomplished by effectively following non-deterministically.
-            Call using "fsm3 = fsm1 + fsm2"
+        Concatenate two finite state machines together.
+        For example, if self accepts "0*" and other accepts "1+(0|1)",
+        will return a finite state machine accepting "0*1+(0|1)".
+        Accomplished by effectively following non-deterministically.
+        Call using "fsm3 = fsm1 + fsm2"
         '''
         return self.concatenate(other)
 
     def star(self):
         '''
-            If the present FSM accepts X, returns an FSM accepting X* (i.e. 0
-            or more Xes). This is NOT as simple as naively connecting the final
-            states back to the initial state: see (b*ab)* for example.
+        If the present FSM accepts X, returns an FSM accepting X* (i.e. 0
+        or more Xes). This is NOT as simple as naively connecting the final
+        states back to the initial state: see (b*ab)* for example.
         '''
         alphabet = self.alphabet
 
@@ -341,7 +341,7 @@ class Fsm:
 
     def times(self, multiplier):
         '''
-            Given an FSM and a multiplier, return the multiplied FSM.
+        Given an FSM and a multiplier, return the multiplied FSM.
         '''
         if multiplier < 0:
             raise Exception(f"Can't multiply an FSM by {repr(multiplier)}")
@@ -353,8 +353,8 @@ class Fsm:
 
         def final(state):
             '''
-                If the initial state is final then multiplying doesn't alter
-                that
+            If the initial state is final then multiplying doesn't alter
+            that
             '''
             for (substate, iteration) in state:
                 if substate == self.initial \
@@ -383,68 +383,68 @@ class Fsm:
 
     def __mul__(self, multiplier):
         '''
-            Given an FSM and a multiplier, return the multiplied FSM.
+        Given an FSM and a multiplier, return the multiplied FSM.
         '''
         return self.times(multiplier)
 
     def union(*fsms):
         '''
-            Treat `fsms` as a collection of arbitrary FSMs and return the union
-            FSM. Can be used as `fsm1.union(fsm2, ...)` or
-            `fsm.union(fsm1, ...)`. `fsms` may be empty.
+        Treat `fsms` as a collection of arbitrary FSMs and return the union
+        FSM. Can be used as `fsm1.union(fsm2, ...)` or
+        `fsm.union(fsm1, ...)`. `fsms` may be empty.
         '''
         return parallel(fsms, any)
 
     def __or__(self, other):
         '''
-            Alternation.
-            Return a finite state machine which accepts any sequence of symbols
-            that is accepted by either self or other. Note that the set of
-            strings recognised by the two FSMs undergoes a set union.
-            Call using "fsm3 = fsm1 | fsm2"
+        Alternation.
+        Return a finite state machine which accepts any sequence of symbols
+        that is accepted by either self or other. Note that the set of
+        strings recognised by the two FSMs undergoes a set union.
+        Call using "fsm3 = fsm1 | fsm2"
         '''
         return self.union(other)
 
     def intersection(*fsms):
         '''
-            Intersection.
-            Take FSMs and AND them together. That is, return an FSM which
-            accepts any sequence of symbols that is accepted by both of the
-            original FSMs. Note that the set of strings recognised by the two
-            FSMs undergoes a set intersection operation.
-            Call using "fsm3 = fsm1 & fsm2"
+        Intersection.
+        Take FSMs and AND them together. That is, return an FSM which
+        accepts any sequence of symbols that is accepted by both of the
+        original FSMs. Note that the set of strings recognised by the two
+        FSMs undergoes a set intersection operation.
+        Call using "fsm3 = fsm1 & fsm2"
         '''
         return parallel(fsms, all)
 
     def __and__(self, other):
         '''
-            Treat the FSMs as sets of strings and return the intersection of
-            those sets in the form of a new FSM.
+        Treat the FSMs as sets of strings and return the intersection of
+        those sets in the form of a new FSM.
         '''
         return self.intersection(other)
 
     def symmetric_difference(*fsms):
         '''
-            Treat `fsms` as a collection of sets of strings and compute the
-            symmetric difference of them all. The python set method only allows
-            two sets to be operated on at once, but we go the extra mile since
-            it's not too hard.
+        Treat `fsms` as a collection of sets of strings and compute the
+        symmetric difference of them all. The python set method only allows
+        two sets to be operated on at once, but we go the extra mile since
+        it's not too hard.
         '''
         return parallel(fsms, lambda accepts: (accepts.count(True) % 2) == 1)
 
     def __xor__(self, other):
         '''
-            Symmetric difference. Returns an FSM which recognises only the
-            strings recognised by `self` or `other` but not both.
+        Symmetric difference. Returns an FSM which recognises only the
+        strings recognised by `self` or `other` but not both.
         '''
         return self.symmetric_difference(other)
 
     def everythingbut(self):
         '''
-            Return a finite state machine which will accept any string NOT
-            accepted by self, and will not accept any string accepted by self.
-            This is more complicated if there are missing transitions, because
-            the missing "dead" state must now be reified.
+        Return a finite state machine which will accept any string NOT
+        accepted by self, and will not accept any string accepted by self.
+        This is more complicated if there are missing transitions, because
+        the missing "dead" state must now be reified.
         '''
         alphabet = self.alphabet
 
@@ -466,8 +466,8 @@ class Fsm:
 
     def reversed(self):
         '''
-            Return a new FSM such that for every string that self accepts (e.g.
-            "beer", the new FSM accepts the reversed string ("reeb").
+        Return a new FSM such that for every string that self accepts (e.g.
+        "beer", the new FSM accepts the reversed string ("reeb").
         '''
         alphabet = self.alphabet
 
@@ -499,8 +499,8 @@ class Fsm:
 
     def __reversed__(self):
         '''
-            Return a new FSM such that for every string that self accepts (e.g.
-            "beer", the new FSM accepts the reversed string ("reeb").
+        Return a new FSM such that for every string that self accepts (e.g.
+        "beer", the new FSM accepts the reversed string ("reeb").
         '''
         return self.reversed()
 
@@ -522,24 +522,24 @@ class Fsm:
 
     def empty(self):
         '''
-            An FSM is empty if it recognises no strings. An FSM may be
-            arbitrarily complicated and have arbitrarily many final states
-            while still recognising no strings because those final states may
-            all be inaccessible from the initial state. Equally, an FSM may be
-            non-empty despite having an empty alphabet if the initial state is
-            final.
+        An FSM is empty if it recognises no strings. An FSM may be
+        arbitrarily complicated and have arbitrarily many final states
+        while still recognising no strings because those final states may
+        all be inaccessible from the initial state. Equally, an FSM may be
+        non-empty despite having an empty alphabet if the initial state is
+        final.
         '''
         return not self.islive(self.initial)
 
     def strings(self):
         '''
-            Generate strings (lists of symbols) that this FSM accepts. Since
-            there may be infinitely many of these we use a generator instead of
-            constructing a static list. Strings will be sorted in order of
-            length and then lexically. This procedure uses arbitrary amounts of
-            memory but is very fast. There may be more efficient ways to do
-            this, that I haven't investigated yet. You can use this in list
-            comprehensions.
+        Generate strings (lists of symbols) that this FSM accepts. Since
+        there may be infinitely many of these we use a generator instead of
+        constructing a static list. Strings will be sorted in order of
+        length and then lexically. This procedure uses arbitrary amounts of
+        memory but is very fast. There may be more efficient ways to do
+        this, that I haven't investigated yet. You can use this in list
+        comprehensions.
         '''
 
         # Many FSMs have "dead states". Once you reach a dead state, you can no
@@ -577,43 +577,43 @@ class Fsm:
 
     def __iter__(self):
         '''
-            This allows you to do `for string in fsm1` as a list comprehension!
+        This allows you to do `for string in fsm1` as a list comprehension!
         '''
         return self.strings()
 
     def equivalent(self, other):
         '''
-            Two FSMs are considered equivalent if they recognise the same
-            strings. Or, to put it another way, if their symmetric difference
-            recognises no strings.
+        Two FSMs are considered equivalent if they recognise the same
+        strings. Or, to put it another way, if their symmetric difference
+        recognises no strings.
         '''
         return (self ^ other).empty()
 
     def __eq__(self, other):
         '''
-            You can use `fsm1 == fsm2` to determine whether two FSMs recognise
-            the same strings.
+        You can use `fsm1 == fsm2` to determine whether two FSMs recognise
+        the same strings.
         '''
         return self.equivalent(other)
 
     def different(self, other):
         '''
-            Two FSMs are considered different if they have a non-empty
-            symmetric difference.
+        Two FSMs are considered different if they have a non-empty
+        symmetric difference.
         '''
         return not (self ^ other).empty()
 
     def __ne__(self, other):
         '''
-            Use `fsm1 != fsm2` to determine whether two FSMs recognise
-            different strings.
+        Use `fsm1 != fsm2` to determine whether two FSMs recognise
+        different strings.
         '''
         return self.different(other)
 
     def difference(*fsms):
         '''
-            Difference. Returns an FSM which recognises only the strings
-            recognised by the first FSM in the list, but none of the others.
+        Difference. Returns an FSM which recognises only the strings
+        recognised by the first FSM in the list, but none of the others.
         '''
         return parallel(
             fsms,
@@ -625,8 +625,8 @@ class Fsm:
 
     def cardinality(self):
         '''
-            Consider the FSM as a set of strings and return the cardinality of
-            that set, or raise an OverflowError if there are infinitely many
+        Consider the FSM as a set of strings and return the cardinality of
+        that set, or raise an OverflowError if there are infinitely many
         '''
         num_strings = {}
 
@@ -659,80 +659,80 @@ class Fsm:
 
     def __len__(self):
         '''
-            Consider the FSM as a set of strings and return the cardinality of
-            that set, or raise an OverflowError if there are infinitely many
+        Consider the FSM as a set of strings and return the cardinality of
+        that set, or raise an OverflowError if there are infinitely many
         '''
         return self.cardinality()
 
     def isdisjoint(self, other):
         '''
-            Treat `self` and `other` as sets of strings and see if they are
-            disjoint
+        Treat `self` and `other` as sets of strings and see if they are
+        disjoint
         '''
         return (self & other).empty()
 
     def issubset(self, other):
         '''
-            Treat `self` and `other` as sets of strings and see if `self` is a
-            subset of `other`... `self` recognises no strings which `other`
-            doesn't.
+        Treat `self` and `other` as sets of strings and see if `self` is a
+        subset of `other`... `self` recognises no strings which `other`
+        doesn't.
         '''
         return (self - other).empty()
 
     def __le__(self, other):
         '''
-            Treat `self` and `other` as sets of strings and see if `self` is a
-            subset of `other`... `self` recognises no strings which `other`
-            doesn't.
+        Treat `self` and `other` as sets of strings and see if `self` is a
+        subset of `other`... `self` recognises no strings which `other`
+        doesn't.
         '''
         return self.issubset(other)
 
     def ispropersubset(self, other):
         '''
-            Treat `self` and `other` as sets of strings and see if `self` is a
-            proper subset of `other`.
+        Treat `self` and `other` as sets of strings and see if `self` is a
+        proper subset of `other`.
         '''
         return self <= other and self != other
 
     def __lt__(self, other):
         '''
-            Treat `self` and `other` as sets of strings and see if `self` is a
-            strict subset of `other`.
+        Treat `self` and `other` as sets of strings and see if `self` is a
+        strict subset of `other`.
         '''
         return self.ispropersubset(other)
 
     def issuperset(self, other):
         '''
-            Treat `self` and `other` as sets of strings and see if `self` is a
-            superset of `other`.
+        Treat `self` and `other` as sets of strings and see if `self` is a
+        superset of `other`.
         '''
         return (other - self).empty()
 
     def __ge__(self, other):
         '''
-            Treat `self` and `other` as sets of strings and see if `self` is a
-            superset of `other`.
+        Treat `self` and `other` as sets of strings and see if `self` is a
+        superset of `other`.
         '''
         return self.issuperset(other)
 
     def ispropersuperset(self, other):
         '''
-            Treat `self` and `other` as sets of strings and see if `self` is a
-            proper superset of `other`.
+        Treat `self` and `other` as sets of strings and see if `self` is a
+        proper superset of `other`.
         '''
         return self >= other and self != other
 
     def __gt__(self, other):
         '''
-            Treat `self` and `other` as sets of strings and see if `self` is a
-            strict superset of `other`.
+        Treat `self` and `other` as sets of strings and see if `self` is a
+        strict superset of `other`.
         '''
         return self.ispropersuperset(other)
 
     def copy(self):
         '''
-            For completeness only, since `set.copy()` also exists. FSM objects
-            are immutable, so I can see only very odd reasons to need this.
+        For completeness only, since `set.copy()` also exists. FSM objects
+        are immutable, so I can see only very odd reasons to need this.
         '''
         return Fsm(
             alphabet=self.alphabet,
@@ -744,12 +744,12 @@ class Fsm:
 
     def derive(self, input):
         '''
-            Compute the Brzozowski derivative of this FSM with respect to the
-            input string of symbols.
-            <https://en.wikipedia.org/wiki/Brzozowski_derivative>
-            If any of the symbols are not members of the alphabet, that's a
-            `KeyError`. If you fall into oblivion, then the derivative is an
-            FSM accepting no strings.
+        Compute the Brzozowski derivative of this FSM with respect to the
+        input string of symbols.
+        <https://en.wikipedia.org/wiki/Brzozowski_derivative>
+        If any of the symbols are not members of the alphabet, that's a
+        `KeyError`. If you fall into oblivion, then the derivative is an
+        FSM accepting no strings.
         '''
         try:
             # Consume the input string.
@@ -783,9 +783,9 @@ class Fsm:
 
 def null(alphabet):
     '''
-        An FSM accepting nothing (not even the empty string). This is
-        demonstrates that this is possible, and is also extremely useful
-        in some situations
+    An FSM accepting nothing (not even the empty string). This is
+    demonstrates that this is possible, and is also extremely useful
+    in some situations
     '''
     return Fsm(
         alphabet=alphabet,
@@ -800,8 +800,8 @@ def null(alphabet):
 
 def epsilon(alphabet):
     '''
-        Return an FSM matching an empty string, "", only.
-        This is very useful in many situations
+    Return an FSM matching an empty string, "", only.
+    This is very useful in many situations
     '''
     return Fsm(
         alphabet=alphabet,
@@ -814,9 +814,9 @@ def epsilon(alphabet):
 
 def parallel(fsms, test):
     '''
-        Crawl several FSMs in parallel, mapping the states of a larger
-        meta-FSM. To determine whether a state in the larger FSM is final, pass
-        all of the finality statuses (e.g. [True, False, False] to `test`.
+    Crawl several FSMs in parallel, mapping the states of a larger
+    meta-FSM. To determine whether a state in the larger FSM is final, pass
+    all of the finality statuses (e.g. [True, False, False] to `test`.
     '''
     alphabet = set().union(*[fsm.alphabet for fsm in fsms])
 
@@ -854,10 +854,10 @@ def parallel(fsms, test):
 
 def crawl(alphabet, initial, final, follow):
     '''
-        Given the above conditions and instructions, crawl a new unknown FSM,
-        mapping its states, final states and transitions. Return the new FSM.
-        This is a pretty powerful procedure which could potentially go on
-        forever if you supply an evil version of follow().
+    Given the above conditions and instructions, crawl a new unknown FSM,
+    mapping its states, final states and transitions. Return the new FSM.
+    This is a pretty powerful procedure which could potentially go on
+    forever if you supply an evil version of follow().
     '''
 
     states = [initial]

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -359,8 +359,8 @@ class Fsm:
             for (substate, iteration) in state:
                 if substate == self.initial \
                    and (
-                       self.initial in self.finals or
-                       iteration == multiplier
+                       self.initial in self.finals
+                       or iteration == multiplier
                    ):
                     return True
             return False

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -358,10 +358,10 @@ class Fsm:
             '''
             for (substate, iteration) in state:
                 if substate == self.initial \
-                  and (
-                    self.initial in self.finals or
-                    iteration == multiplier
-                  ):
+                   and (
+                       self.initial in self.finals or
+                       iteration == multiplier
+                   ):
                     return True
             return False
 

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -47,10 +47,10 @@ class AnythingElse(Enum):
         return hash(type(self))
 
     def __str__(self, /) -> str:
-        return 'ANYTHING_ELSE'
+        return "ANYTHING_ELSE"
 
     def __repr__(self, /) -> str:
-        return 'ANYTHING_ELSE'
+        return "ANYTHING_ELSE"
 
 
 ANYTHING_ELSE = AnythingElse.TOKEN

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -64,6 +64,7 @@ class OblivionError(Exception):
         warrants an out-of-band signal which will reduce the complexity of the
         new FSM's map.
     '''
+
     pass
 
 
@@ -88,6 +89,7 @@ class Fsm:
         closure), intersected, and simplified.
         The majority of these methods are available using operator overloads.
     '''
+
     initial: state_type
     finals: set[state_type]
     alphabet: set[alpha_type]

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -233,13 +233,13 @@ def test_crawl_reduction():
 def test_bug_28():
     # This is (ab*)* and it caused some defects.
     abstar = Fsm(
-        alphabet={'a', 'b'},
+        alphabet={"a", "b"},
         states={0, 1},
         initial=0,
         finals={1},
         map={
-            0: {'a': 1},
-            1: {'b': 1}
+            0: {"a": 1},
+            1: {"b": 1}
         }
     )
     assert abstar.accepts("a")
@@ -568,14 +568,14 @@ def test_dead_default():
     assert blockquote.accepts(["/", "*", "whatever", "*", "/"])
     assert not blockquote.accepts(["*", "*", "whatever", "*", "/"])
     assert str(blockquote) \
-        == '  name final? * / ANYTHING_ELSE \n' \
-        + '--------------------------------\n' \
-        + '* 0    False    1               \n' \
-        + '  1    False  2                 \n' \
-        + '  2    False  3 2 2             \n' \
-        + '  3    False  3 4 2             \n' \
-        + '  4    True                     \n' \
-        + '  5    False                    \n'
+        == "  name final? * / ANYTHING_ELSE \n" \
+        + "--------------------------------\n" \
+        + "* 0    False    1               \n" \
+        + "  1    False  2                 \n" \
+        + "  2    False  3 2 2             \n" \
+        + "  3    False  3 4 2             \n" \
+        + "  4    True                     \n" \
+        + "  5    False                    \n"
     blockquote | blockquote
     blockquote & blockquote
     blockquote ^ blockquote
@@ -743,16 +743,16 @@ def test_bug_36():
         }
     )
     etc2 = Fsm(
-        alphabet={'s', ANYTHING_ELSE},
+        alphabet={"s", ANYTHING_ELSE},
         states={0, 1},
         initial=0,
         finals={1},
         map={
             0: {
-                's': 1
+                "s": 1
             },
             1: {
-                's': 1,
+                "s": 1,
                 ANYTHING_ELSE: 1
             }
         }

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -559,10 +559,10 @@ def test_dead_default():
         initial=0,
         finals={4},
         map={
-                0: {"/": 1},
-                1: {"*": 2},
-                2: {"/": 2, ANYTHING_ELSE: 2, "*": 3},
-                3: {"/": 4, ANYTHING_ELSE: 2, "*": 3},
+            0: {"/": 1},
+            1: {"*": 2},
+            2: {"/": 2, ANYTHING_ELSE: 2, "*": 3},
+            3: {"/": 4, ANYTHING_ELSE: 2, "*": 3},
         }
     )
     assert blockquote.accepts(["/", "*", "whatever", "*", "/"])

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -550,8 +550,8 @@ def test_equivalent(a, b):
 
 def test_dead_default():
     '''
-        You may now omit a transition, or even an entire state, from the map.
-        This affects every usage of `Fsm.map`.
+    You may now omit a transition, or even an entire state, from the map.
+    This affects every usage of `Fsm.map`.
     '''
     blockquote = Fsm(
         alphabet={"/", "*", ANYTHING_ELSE},

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -549,10 +549,10 @@ def test_equivalent(a, b):
 
 
 def test_dead_default():
-    '''
+    """
     You may now omit a transition, or even an entire state, from the map.
     This affects every usage of `Fsm.map`.
-    '''
+    """
     blockquote = Fsm(
         alphabet={"/", "*", ANYTHING_ELSE},
         states={0, 1, 2, 3, 4, 5},

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -567,15 +567,15 @@ def test_dead_default():
     )
     assert blockquote.accepts(["/", "*", "whatever", "*", "/"])
     assert not blockquote.accepts(["*", "*", "whatever", "*", "/"])
-    assert str(blockquote) == \
-        '  name final? * / ANYTHING_ELSE \n' + \
-        '--------------------------------\n' + \
-        '* 0    False    1               \n' + \
-        '  1    False  2                 \n' + \
-        '  2    False  3 2 2             \n' + \
-        '  3    False  3 4 2             \n' + \
-        '  4    True                     \n' + \
-        '  5    False                    \n'
+    assert str(blockquote) \
+        == '  name final? * / ANYTHING_ELSE \n' \
+        + '--------------------------------\n' \
+        + '* 0    False    1               \n' \
+        + '  1    False  2                 \n' \
+        + '  2    False  3 2 2             \n' \
+        + '  3    False  3 4 2             \n' \
+        + '  4    True                     \n' \
+        + '  5    False                    \n'
     blockquote | blockquote
     blockquote & blockquote
     blockquote ^ blockquote

--- a/greenery/mult_test.py
+++ b/greenery/mult_test.py
@@ -60,18 +60,18 @@ def test_odd_bug():
 def test_mult_common():
     a = Charclass("a")
     assert Mult(a, Multiplier(Bound(3), Bound(4))) \
-        .common(Mult(a, Multiplier(Bound(2), Bound(5)))) == \
-        Mult(a, Multiplier(Bound(2), Bound(3)))
+        .common(Mult(a, Multiplier(Bound(2), Bound(5)))) \
+        == Mult(a, Multiplier(Bound(2), Bound(3)))
     assert Mult(a, Multiplier(Bound(2), INF)) \
-        .common(Mult(a, Multiplier(Bound(1), Bound(5)))) == \
-        Mult(a, Multiplier(Bound(1), Bound(5)))
+        .common(Mult(a, Multiplier(Bound(1), Bound(5)))) \
+        == Mult(a, Multiplier(Bound(1), Bound(5)))
     assert Mult(a, Multiplier(Bound(3), INF)) \
-        .common(Mult(a, Multiplier(Bound(2), INF))) == \
-        Mult(a, Multiplier(Bound(2), INF))
+        .common(Mult(a, Multiplier(Bound(2), INF))) \
+        == Mult(a, Multiplier(Bound(2), INF))
 
 
 def test_mult_dock():
     a = Charclass("a")
     assert Mult(a, Multiplier(Bound(4), Bound(5))) \
-        .dock(Mult(a, Multiplier(Bound(3), Bound(3)))) == \
-        Mult(a, Multiplier(Bound(1), Bound(2)))
+        .dock(Mult(a, Multiplier(Bound(3), Bound(3)))) \
+        == Mult(a, Multiplier(Bound(1), Bound(2)))

--- a/greenery/multiplier.py
+++ b/greenery/multiplier.py
@@ -17,7 +17,7 @@ from .bound import INF, Bound
 
 @dataclass(frozen=True)
 class Multiplier:
-    '''
+    """
     A min and a max. The vast majority of characters in regular expressions
     occur without a specific multiplier, which is implicitly equivalent to
     a min of 1 and a max of 1, but many more have explicit multipliers like
@@ -27,7 +27,7 @@ class Multiplier:
     also permit a max of 0 (iff min is 0 too). This allows the multiplier
     `ZERO` to exist, which actually are quite useful in their own special
     way.
-    '''
+    """
 
     min: Bound
     max: Bound
@@ -71,7 +71,7 @@ class Multiplier:
         return "{" + str(self.min) + "," + str(self.max) + "}"
 
     def canmultiplyby(self, other):
-        '''
+        """
         Multiplication is not well-defined for all pairs of multipliers
         because the resulting possibilities do not necessarily form a
         continuous range.
@@ -85,12 +85,12 @@ class Multiplier:
         is equal to {pr, (p+q)(r+s)} only if s=0 or qr+1 >= p. If not, then
         at least one gap appears in the range. The first inaccessible
         number is (p+q)r+1. And no, multiplication is not commutative
-        '''
+        """
         return other.optional == Bound(0) \
             or self.optional * other.mandatory + Bound(1) >= self.mandatory
 
     def __mul__(self, other):
-        '''Multiply this multiplier by another'''
+        """Multiply this multiplier by another"""
         if not self.canmultiplyby(other):
             raise Exception(
                 f"Can't multiply {repr(self)} by {repr(other)}"
@@ -98,35 +98,35 @@ class Multiplier:
         return Multiplier(self.min * other.min, self.max * other.max)
 
     def __add__(self, other):
-        '''Add two multipliers together'''
+        """Add two multipliers together"""
         return Multiplier(self.min + other.min, self.max + other.max)
 
     def __sub__(self, other):
-        '''
+        """
         Subtract another multiplier from this one.
         Caution: multipliers are not totally ordered.
         This operation is not meaningful for all pairs of multipliers.
-        '''
+        """
         mandatory = self.mandatory - other.mandatory
         optional = self.optional - other.optional
         return Multiplier(mandatory, mandatory + optional)
 
     def canintersect(self, other):
-        '''
+        """
         Intersection is not well-defined for all pairs of multipliers.
         For example:
             {2,3} & {3,4} = {3}
             {2,} & {1,7} = {2,7}
             {2} & {5} = ERROR
-        '''
+        """
         return not (self.max < other.min or other.max < self.min)
 
     def __and__(self, other):
-        '''
+        """
         Find the intersection of two multipliers: that is, a third
         multiplier expressing the range covered by both of the originals.
         This is not defined for all multipliers since they may not overlap.
-        '''
+        """
         if not self.canintersect(other):
             raise Exception(
                 f"Can't compute intersection of {repr(self)} and {repr(other)}"
@@ -136,21 +136,21 @@ class Multiplier:
         return Multiplier(a, b)
 
     def canunion(self, other):
-        '''
+        """
         Union is not defined for all pairs of multipliers.
         E.g. {0,1} | {3,4} -> nope
-        '''
+        """
         return not (
             self.max + Bound(1) < other.min
             or other.max + Bound(1) < self.min
         )
 
     def __or__(self, other):
-        '''
+        """
         Find the union of two multipliers: that is, a third multiplier
         expressing the range covered by either of the originals. This is
         not defined for all multipliers since they may not intersect.
-        '''
+        """
         if not self.canunion(other):
             raise Exception(
                 f"Can't compute the union of {repr(self)} and {repr(other)}"
@@ -160,11 +160,11 @@ class Multiplier:
         return Multiplier(a, b)
 
     def common(self, other):
-        '''
+        """
         Find the shared part of two multipliers. This is the largest
         multiplier which can be safely subtracted from both the originals.
         This may return the `ZERO` multiplier.
-        '''
+        """
         mandatory = min(self.mandatory, other.mandatory)
         optional = min(self.optional, other.optional)
         return Multiplier(mandatory, mandatory + optional)

--- a/greenery/multiplier.py
+++ b/greenery/multiplier.py
@@ -141,8 +141,8 @@ class Multiplier:
             E.g. {0,1} | {3,4} -> nope
         '''
         return not (
-            self.max + Bound(1) < other.min or
-            other.max + Bound(1) < self.min
+            self.max + Bound(1) < other.min
+            or other.max + Bound(1) < self.min
         )
 
     def __or__(self, other):

--- a/greenery/multiplier.py
+++ b/greenery/multiplier.py
@@ -41,8 +41,8 @@ class Multiplier:
             )
         if self.min > self.max:
             raise Exception(
-                "Invalid multiplier bounds: "
-                f"{repr(self.min)} and {repr(self.max)}"
+                "Invalid multiplier bounds:"
+                f" {repr(self.min)} and {repr(self.max)}"
             )
 
         # More useful than "min" and "max" in many situations
@@ -86,8 +86,8 @@ class Multiplier:
             at least one gap appears in the range. The first inaccessible
             number is (p+q)r+1. And no, multiplication is not commutative
         '''
-        return other.optional == Bound(0) or \
-            self.optional * other.mandatory + Bound(1) >= self.mandatory
+        return other.optional == Bound(0) \
+            or self.optional * other.mandatory + Bound(1) >= self.mandatory
 
     def __mul__(self, other):
         '''Multiply this multiplier by another'''

--- a/greenery/multiplier.py
+++ b/greenery/multiplier.py
@@ -37,12 +37,12 @@ class Multiplier:
     def __post_init__(self):
         if self.min == INF:
             raise Exception(
-                f"Minimum bound of a multiplier can't be {repr(INF)}"
+                f"Minimum bound of a multiplier can't be {INF!r}"
             )
         if self.min > self.max:
             raise Exception(
                 "Invalid multiplier bounds:"
-                f" {repr(self.min)} and {repr(self.max)}"
+                f" {self.min!r} and {self.max!r}"
             )
 
         # More useful than "min" and "max" in many situations
@@ -57,12 +57,12 @@ class Multiplier:
         return hash((self.min, self.max))
 
     def __repr__(self):
-        return f"Multiplier({repr(self.min)}, {repr(self.max)})"
+        return f"Multiplier({self.min!r}, {self.max!r})"
 
     def __str__(self):
         if self.max == Bound(0):
             raise Exception(
-                f"Can't serialise a multiplier with bound {repr(self.max)}"
+                f"Can't serialise a multiplier with bound {self.max!r}"
             )
         if self in symbolic.keys():
             return symbolic[self]
@@ -93,7 +93,7 @@ class Multiplier:
         """Multiply this multiplier by another"""
         if not self.canmultiplyby(other):
             raise Exception(
-                f"Can't multiply {repr(self)} by {repr(other)}"
+                f"Can't multiply {self!r} by {other!r}"
             )
         return Multiplier(self.min * other.min, self.max * other.max)
 
@@ -129,7 +129,7 @@ class Multiplier:
         """
         if not self.canintersect(other):
             raise Exception(
-                f"Can't compute intersection of {repr(self)} and {repr(other)}"
+                f"Can't compute intersection of {self!r} and {other!r}"
             )
         a = max(self.min, other.min)
         b = min(self.max, other.max)
@@ -153,7 +153,7 @@ class Multiplier:
         """
         if not self.canunion(other):
             raise Exception(
-                f"Can't compute the union of {repr(self)} and {repr(other)}"
+                f"Can't compute the union of {self!r} and {other!r}"
             )
         a = min(self.min, other.min)
         b = max(self.max, other.max)

--- a/greenery/multiplier.py
+++ b/greenery/multiplier.py
@@ -28,6 +28,7 @@ class Multiplier:
         `ZERO` to exist, which actually are quite useful in their own special
         way.
     '''
+
     min: Bound
     max: Bound
     mandatory: Bound = field(init=False)

--- a/greenery/multiplier.py
+++ b/greenery/multiplier.py
@@ -18,15 +18,15 @@ from .bound import INF, Bound
 @dataclass(frozen=True)
 class Multiplier:
     '''
-        A min and a max. The vast majority of characters in regular expressions
-        occur without a specific multiplier, which is implicitly equivalent to
-        a min of 1 and a max of 1, but many more have explicit multipliers like
-        "*" (min = 0, max = inf) and so on.
+    A min and a max. The vast majority of characters in regular expressions
+    occur without a specific multiplier, which is implicitly equivalent to
+    a min of 1 and a max of 1, but many more have explicit multipliers like
+    "*" (min = 0, max = inf) and so on.
 
-        Although it seems odd and can lead to some confusing edge cases, we do
-        also permit a max of 0 (iff min is 0 too). This allows the multiplier
-        `ZERO` to exist, which actually are quite useful in their own special
-        way.
+    Although it seems odd and can lead to some confusing edge cases, we do
+    also permit a max of 0 (iff min is 0 too). This allows the multiplier
+    `ZERO` to exist, which actually are quite useful in their own special
+    way.
     '''
 
     min: Bound
@@ -72,19 +72,19 @@ class Multiplier:
 
     def canmultiplyby(self, other):
         '''
-            Multiplication is not well-defined for all pairs of multipliers
-            because the resulting possibilities do not necessarily form a
-            continuous range.
+        Multiplication is not well-defined for all pairs of multipliers
+        because the resulting possibilities do not necessarily form a
+        continuous range.
 
-            For example:
-                {0,x} * {0,y} = {0,x*y}
-                {2} * {3} = {6}
-                {2} * {1,2} = ERROR
+        For example:
+            {0,x} * {0,y} = {0,x*y}
+            {2} * {3} = {6}
+            {2} * {1,2} = ERROR
 
-            The proof isn't simple but suffice it to say that {p,p+q} * {r,r+s}
-            is equal to {pr, (p+q)(r+s)} only if s=0 or qr+1 >= p. If not, then
-            at least one gap appears in the range. The first inaccessible
-            number is (p+q)r+1. And no, multiplication is not commutative
+        The proof isn't simple but suffice it to say that {p,p+q} * {r,r+s}
+        is equal to {pr, (p+q)(r+s)} only if s=0 or qr+1 >= p. If not, then
+        at least one gap appears in the range. The first inaccessible
+        number is (p+q)r+1. And no, multiplication is not commutative
         '''
         return other.optional == Bound(0) \
             or self.optional * other.mandatory + Bound(1) >= self.mandatory
@@ -103,9 +103,9 @@ class Multiplier:
 
     def __sub__(self, other):
         '''
-            Subtract another multiplier from this one.
-            Caution: multipliers are not totally ordered.
-            This operation is not meaningful for all pairs of multipliers.
+        Subtract another multiplier from this one.
+        Caution: multipliers are not totally ordered.
+        This operation is not meaningful for all pairs of multipliers.
         '''
         mandatory = self.mandatory - other.mandatory
         optional = self.optional - other.optional
@@ -113,19 +113,19 @@ class Multiplier:
 
     def canintersect(self, other):
         '''
-            Intersection is not well-defined for all pairs of multipliers.
-            For example:
-                {2,3} & {3,4} = {3}
-                {2,} & {1,7} = {2,7}
-                {2} & {5} = ERROR
+        Intersection is not well-defined for all pairs of multipliers.
+        For example:
+            {2,3} & {3,4} = {3}
+            {2,} & {1,7} = {2,7}
+            {2} & {5} = ERROR
         '''
         return not (self.max < other.min or other.max < self.min)
 
     def __and__(self, other):
         '''
-            Find the intersection of two multipliers: that is, a third
-            multiplier expressing the range covered by both of the originals.
-            This is not defined for all multipliers since they may not overlap.
+        Find the intersection of two multipliers: that is, a third
+        multiplier expressing the range covered by both of the originals.
+        This is not defined for all multipliers since they may not overlap.
         '''
         if not self.canintersect(other):
             raise Exception(
@@ -137,8 +137,8 @@ class Multiplier:
 
     def canunion(self, other):
         '''
-            Union is not defined for all pairs of multipliers.
-            E.g. {0,1} | {3,4} -> nope
+        Union is not defined for all pairs of multipliers.
+        E.g. {0,1} | {3,4} -> nope
         '''
         return not (
             self.max + Bound(1) < other.min
@@ -147,9 +147,9 @@ class Multiplier:
 
     def __or__(self, other):
         '''
-            Find the union of two multipliers: that is, a third multiplier
-            expressing the range covered by either of the originals. This is
-            not defined for all multipliers since they may not intersect.
+        Find the union of two multipliers: that is, a third multiplier
+        expressing the range covered by either of the originals. This is
+        not defined for all multipliers since they may not intersect.
         '''
         if not self.canunion(other):
             raise Exception(
@@ -161,9 +161,9 @@ class Multiplier:
 
     def common(self, other):
         '''
-            Find the shared part of two multipliers. This is the largest
-            multiplier which can be safely subtracted from both the originals.
-            This may return the `ZERO` multiplier.
+        Find the shared part of two multipliers. This is the largest
+        multiplier which can be safely subtracted from both the originals.
+        This may return the `ZERO` multiplier.
         '''
         mandatory = min(self.mandatory, other.mandatory)
         optional = min(self.optional, other.optional)

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -219,9 +219,9 @@ def match_multiplicand(string, i):
     # explicitly non-capturing "(?:...)" syntax. No special significance
     try:
         j = static(string, i, "(?")
-        j, st = select_static(string, j, ':', 'P<')
-        if st == 'P<':
-            j, group_name = read_until(string, j, '>')
+        j, st = select_static(string, j, ":", "P<")
+        if st == "P<":
+            j, group_name = read_until(string, j, ">")
         pattern, j = match_pattern(string, j)
         j = static(string, j, ")")
         return pattern, j

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -350,5 +350,5 @@ def parse(string: str):
     """
     obj, i = match_pattern(string, 0)
     if i != len(string):
-        raise Exception(f"Could not parse {string!r} beyond index {str(i)}")
+        raise Exception(f"Could not parse {string!r} beyond index {i}")
     return obj

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -12,10 +12,10 @@ from .rxelems import Conc, Mult, Pattern
 
 
 class NoMatch(Exception):
-    '''
+    """
     Thrown when parsing fails.
     Almost always caught and almost never fatal
-    '''
+    """
 
     pass
 
@@ -47,7 +47,7 @@ def select_static(string, i, *statics):
 
 
 def unescape_hex(string, i):
-    '''Turn e.g. "\\x40" into "@". Exactly two hex digits'''
+    """Turn e.g. "\\x40" into "@". Exactly two hex digits"""
     hex_digits = "0123456789AaBbCcDdEeFf"
 
     j = static(string, i, "\\x")
@@ -344,10 +344,10 @@ def match_pattern(string: str, i):
 
 
 def parse(string: str):
-    '''
+    """
     Parse a full string and return a `Pattern` object. Fail if
     the whole string wasn't parsed
-    '''
+    """
     obj, i = match_pattern(string, 0)
     if i != len(string):
         raise Exception(

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -16,6 +16,7 @@ class NoMatch(Exception):
         Thrown when parsing fails.
         Almost always caught and almost never fatal
     '''
+
     pass
 
 

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -13,8 +13,8 @@ from .rxelems import Conc, Mult, Pattern
 
 class NoMatch(Exception):
     '''
-        Thrown when parsing fails.
-        Almost always caught and almost never fatal
+    Thrown when parsing fails.
+    Almost always caught and almost never fatal
     '''
 
     pass
@@ -345,8 +345,8 @@ def match_pattern(string: str, i):
 
 def parse(string: str):
     '''
-        Parse a full string and return a `Pattern` object. Fail if
-        the whole string wasn't parsed
+    Parse a full string and return a `Pattern` object. Fail if
+    the whole string wasn't parsed
     '''
     obj, i = match_pattern(string, 0)
     if i != len(string):

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -90,7 +90,7 @@ def match_internal_char(string, i):
 
     # single non-special character, not contained
     # inside square brackets
-    char, j = string[i], i+1
+    char, j = string[i], i + 1
     if char in Charclass.classSpecial:
         raise NoMatch
 
@@ -208,7 +208,7 @@ def match_charclass(string: str, i):
         pass
 
     # single non-special character, not contained inside square brackets
-    char, i = string[i], i+1
+    char, i = string[i], i + 1
     if char in Charclass.allSpecial:
         raise NoMatch
 

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -123,7 +123,7 @@ def match_class_interior_1(string, i):
 
         # Be strict here, "d-d" is not allowed
         if firstIndex >= lastIndex:
-            raise NoMatch(f"Range '{first}' to '{last}' not allowed")
+            raise NoMatch(f"Range {first!r} to {last!r} not allowed")
 
         chars = frozenset(chr(i) for i in range(firstIndex, lastIndex + 1))
         return chars, False, k
@@ -350,7 +350,5 @@ def parse(string: str):
     """
     obj, i = match_pattern(string, 0)
     if i != len(string):
-        raise Exception(
-            f"Could not parse '{string}' beyond index {str(i)}"
-        )
+        raise Exception(f"Could not parse {string!r} beyond index {str(i)}")
     return obj

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -894,10 +894,10 @@ class Mult:
 
     def __str__(self):
         if isinstance(self.multiplicand, Pattern):
-            return f"({str(self.multiplicand)}){str(self.multiplier)}"
+            return f"({self.multiplicand}){self.multiplier}"
         if isinstance(self.multiplicand, Charclass):
-            return f"{str(self.multiplicand)}{str(self.multiplier)}"
-        raise Exception(f"Unknown type {str(type(self.multiplicand))}")
+            return f"{self.multiplicand}{self.multiplier}"
+        raise Exception(f"Unknown type {type(self.multiplicand)}")
 
     def to_fsm(self, alphabet=None):
         if alphabet is None:

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -64,6 +64,7 @@ class Conc():
                 # Conc contains "()" (i.e. a `Mult` containing only a `Pattern`
                 # containing the empty string)? That can be removed
                 # e.g. "a()b" -> "ab"
+
                 (
                     mult.multiplicand == Pattern(EMPTYSTRING)
                 ) \
@@ -71,6 +72,7 @@ class Conc():
                 # If a `Mult` has an empty multiplicand, we can only match it
                 # zero times => empty string => remove it entirely
                 # e.g. "a[]{0,3}b" -> "ab"
+
                 or (
                     mult.multiplicand.empty()
                     and mult.multiplier.min == Bound(0)
@@ -407,6 +409,7 @@ def call_fsm(method):
     def new_method(*elems):
         alphabet = set().union(*[elem.alphabet() for elem in elems])
         return from_fsm(fsm_method(*[elem.to_fsm(alphabet) for elem in elems]))
+
     return new_method
 
 
@@ -788,6 +791,7 @@ class Mult:
 
         e.g. a, b{2}, c?, d*, [efg]{2,5}, f{2,}, (anysubpattern)+, .*, ...
     '''
+
     multiplicand: Charclass | Pattern
     multiplier: Multiplier
 

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -797,8 +797,8 @@ class Mult:
 
     def __eq__(self, other):
         return isinstance(other.multiplicand, type(self.multiplicand)) \
-               and self.multiplicand == other.multiplicand \
-               and self.multiplier == other.multiplier
+            and self.multiplicand == other.multiplicand \
+            and self.multiplier == other.multiplier
 
     def __hash__(self):
         return hash((self.multiplicand, self.multiplier))

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -1,7 +1,7 @@
-'''
+"""
 Because of the circularity between `Pattern`, `Conc` and `Mult`, all three
 need to be in the same source file?
-'''
+"""
 
 from __future__ import annotations
 
@@ -24,12 +24,12 @@ from .multiplier import ONE, QM, STAR, ZERO, Multiplier
 
 @dataclass(frozen=True)
 class Conc():
-    '''
+    """
     A `Conc` (short for "concatenation") is a tuple of `Mult`s i.e. an
     unbroken string of mults occurring one after the other.
     e.g. abcde[^fg]*h{4}[a-z]+(subpattern)(subpattern2)
     To express the empty string, use an empty `Conc`, Conc().
-    '''
+    """
 
     mults: tuple[Mult, ...]
 
@@ -184,7 +184,7 @@ class Conc():
         return "".join(str(m) for m in self.mults)
 
     def common(self, other, suffix=False):
-        '''
+        """
         Return the common prefix of these two `Conc`s; that is, the largest
         `Conc` which can be safely beheaded() from the front of both. The
         result could be `EMPTYSTRING`.
@@ -196,7 +196,7 @@ class Conc():
         "AAZY, BBZY" -> "ZY"
         "CZ, CZ" -> "CZ"
         "CY, CZ" -> ""
-        '''
+        """
         mults = []
 
         indices = range(min(len(self.mults), len(other.mults)))
@@ -230,12 +230,12 @@ class Conc():
         return Conc(*mults)
 
     def dock(self, other):
-        '''
+        """
         Subtract another `Conc` from this one.
         This is the opposite of concatenation.
         For example, if ABC + DEF = ABCDEF,
         then logically ABCDEF - DEF = ABC.
-        '''
+        """
 
         # e.g. self has mults at indices [0, 1, 2, 3, 4, 5, 6] len=7
         # e.g. other has mults at indices [0, 1, 2] len=3
@@ -262,10 +262,10 @@ class Conc():
         return Conc(*new)
 
     def behead(self, other):
-        '''
+        """
         As with dock() but the other way around. For example, if
         ABC + DEF = ABCDEF, then ABCDEF.behead(AB) = CDEF.
-        '''
+        """
         # Observe that FEDCBA - BA = FEDC.
         return self.reversed().dock(other.reversed()).reversed()
 
@@ -281,10 +281,10 @@ class _Outside(Enum):
 
 
 def from_fsm(f: Fsm) -> Pattern:
-    '''
+    """
     Turn the supplied finite state machine into a `Pattern`. This is
     accomplished using the Brzozowski algebraic method.
-    '''
+    """
     # Make sure the supplied alphabet is kosher. It must contain only single-
     # character strings or `ANYTHING_ELSE`.
     for symbol in f.alphabet:
@@ -398,12 +398,12 @@ def from_fsm(f: Fsm) -> Pattern:
 
 
 def call_fsm(method):
-    '''
+    """
     Take a method which acts on 0 or more regular expression objects...
     return a new method which simply converts them all to FSMs, calls the
     FSM method on them instead, then converts the result back to a regular
     expression. We do this for several of the more annoying operations.
-    '''
+    """
     fsm_method = getattr(Fsm, method.__name__)
 
     def new_method(*elems):
@@ -415,7 +415,7 @@ def call_fsm(method):
 
 @dataclass(frozen=True)
 class Pattern:
-    '''
+    """
     A `Pattern` (also known as an "alt", short for "alternation") is a
     set of `Conc`s. A `Pattern` expresses multiple alternate possibilities.
     When written out as a regex, these would separated by pipes. A
@@ -429,7 +429,7 @@ class Pattern:
     an upper bound 1, a lower bound 1, and a multiplicand which is a new
     subpattern, "ghi|jkl". This new subpattern again consists of two
     `Conc`s: "ghi" and "jkl".
-    '''
+    """
 
     concs: frozenset[Conc]
 
@@ -466,10 +466,10 @@ class Pattern:
 
     @call_fsm
     def difference(*elems):
-        '''
+        """
         Return a regular expression which matches any string which `self`
         matches but none of the strings which `other` matches.
-        '''
+        """
         pass
 
     def __sub__(self, other):
@@ -613,35 +613,35 @@ class Pattern:
 
     @call_fsm
     def symmetric_difference(*elems):
-        '''
+        """
         Return a regular expression matching only the strings recognised by
         `self` or `other` but not both.
-        '''
+        """
         pass
 
     def __xor__(self, other):
         return self.symmetric_difference(other)
 
     def dock(self, other):
-        '''
+        """
         The opposite of concatenation. Remove a common suffix from the
         present `Pattern`; that is, from each of its constituent concs.
 
         AYZ|BYZ|CYZ - YZ -> A|B|C.
-        '''
+        """
         return Pattern(*[conc.dock(other) for conc in self.concs])
 
     def behead(self, other):
-        '''
+        """
         Like dock() but the other way around. Remove a common prefix from
         the present `Pattern`; that is, from each of its constituent concs.
 
         ZA|ZB|ZC.behead(Z) -> A|B|C
-        '''
+        """
         return Pattern(*[conc.behead(other) for conc in self.concs])
 
     def _commonconc(self, suffix=False):
-        '''
+        """
         Find the longest `Conc` which acts as prefix to every `Conc` in
         this `Pattern`. This could be `EMPTYSTRING`. Return the common
         prefix along with all the leftovers after truncating that common
@@ -652,7 +652,7 @@ class Pattern:
         "CZ|CZ" -> "CZ", "()"
 
         If "suffix" is True, the same result but for suffixes.
-        '''
+        """
         if len(self.concs) == 0:
             raise Exception(f"Can't call _commonconc on {repr(self)}")
 
@@ -674,26 +674,26 @@ class Pattern:
         return Pattern(*(c.reversed() for c in self.concs))
 
     def copy(self):
-        '''
+        """
         For completeness only, since `set.copy()` also exists. `Pattern`s
         are immutable, so I can see only very odd reasons to need this
-        '''
+        """
         return Pattern(*self.concs)
 
     def equivalent(self, other):
-        '''
+        """
         Two `Pattern`s are equivalent if they recognise the same strings.
         Note that in the general case this is actually quite an intensive
         calculation, but far from unsolvable, as we demonstrate here:
-        '''
+        """
         return self.to_fsm().equivalent(other.to_fsm())
 
     def times(self, multiplier):
-        '''
+        """
         Equivalent to repeated concatenation. Multiplier consists of a
         minimum and a maximum; maximum may be infinite (for Kleene star
         closure). Call using "a = b * qm"
-        '''
+        """
         return Pattern(Conc(Mult(self, multiplier)))
 
     def __mul__(self, multiplier):
@@ -701,44 +701,44 @@ class Pattern:
 
     @call_fsm
     def everythingbut(self):
-        '''
+        """
         Return a `Pattern` which will match any string not matched by
         `self`, and which will not match any string matched by `self`.
         Another task which is very difficult in general (and typically
         returns utter garbage when actually printed), but becomes trivial
         to code thanks to FSM routines.
-        '''
+        """
         pass
 
     def derive(self, string):
         return from_fsm(self.to_fsm().derive(string))
 
     def isdisjoint(self, other):
-        '''
+        """
         Treat `self` and `other` as sets of strings and see if they are
         disjoint
-        '''
+        """
         return self.to_fsm().isdisjoint(other.to_fsm())
 
     def matches(self, string):
         return self.to_fsm().accepts(string)
 
     def __contains__(self, string):
-        '''
+        """
         This lets you use the syntax `"a" in pattern` to see whether the
         string "a" is in the set of strings matched by `pattern`.
-        '''
+        """
         return self.matches(string)
 
     def __reversed__(self):
         return self.reversed()
 
     def cardinality(self):
-        '''
+        """
         Consider the regular expression as a set of strings and return the
         cardinality of that set, or raise an OverflowError if there are
         infinitely many.
-        '''
+        """
         # There is no way to do this other than converting to an FSM, because
         # the `Pattern` may allow duplicate routes, such as "a|a".
         return self.to_fsm().cardinality()
@@ -747,12 +747,12 @@ class Pattern:
         return self.cardinality()
 
     def strings(self, otherchar=None):
-        '''
+        """
         Each time next() is called on this iterator, a new string is
         returned which this `Pattern` can match. `StopIteration`
         is raised once all such strings have been returned, although a
         regex with a * in may match infinitely many strings.
-        '''
+        """
 
         # In the case of a regex like "[^abc]", there are infinitely many
         # (well, a very large finite number of) single characters which will
@@ -773,16 +773,16 @@ class Pattern:
             yield "".join(string)
 
     def __iter__(self):
-        '''
+        """
         This allows you to do `for string in pattern` as a list
         comprehension!
-        '''
+        """
         return self.strings()
 
 
 @dataclass(frozen=True)
 class Mult:
-    '''
+    """
     A `Mult` is a combination of a multiplicand with a multiplier (a min
     and a max). The vast majority of characters in regular expressions
     occur without a specific multiplier, which is implicitly equivalent to
@@ -790,7 +790,7 @@ class Mult:
     "*" (min = 0, max = INF) and so on.
 
     e.g. a, b{2}, c?, d*, [efg]{2,5}, f{2,}, (anysubpattern)+, .*, ...
-    '''
+    """
 
     multiplicand: Charclass | Pattern
     multiplier: Multiplier
@@ -807,12 +807,12 @@ class Mult:
         return f"Mult({repr(self.multiplicand)}, {repr(self.multiplier)})"
 
     def dock(self, other):
-        '''
+        """
         "Dock" another `Mult` from this one (i.e. remove part of the tail)
         and return the result. The reverse of concatenation. This is a lot
         trickier.
         e.g. a{4,5} - a{3} = a{1,2}
-        '''
+        """
         if other.multiplicand != self.multiplicand:
             raise Exception(
                 f"Can't subtract {repr(other)} from {repr(self)}"
@@ -820,12 +820,12 @@ class Mult:
         return Mult(self.multiplicand, self.multiplier - other.multiplier)
 
     def common(self, other):
-        '''
+        """
         Return the common part of these two mults. This is the largest
         `Mult` which can be safely subtracted from both the originals. The
         multiplier on this `Mult` could be `ZERO`: this is the case if, for
         example, the multiplicands disagree.
-        '''
+        """
         if self.multiplicand == other.multiplicand:
             return Mult(
                 self.multiplicand,

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -256,7 +256,7 @@ class Conc():
             else:
                 if i != 0:
                     raise Exception(
-                        f"Can't subtract {repr(other)} from {repr(self)}"
+                        f"Can't subtract {other!r} from {self!r}"
                     )
 
         return Conc(*new)
@@ -293,7 +293,7 @@ def from_fsm(f: Fsm) -> Pattern:
         if isinstance(symbol, str) and len(symbol) == 1:
             continue
         raise Exception(
-            f"Symbol {repr(symbol)} cannot be used in a regular expression"
+            f"Symbol {symbol!r} cannot be used in a regular expression"
         )
 
     outside = _Outside.TOKEN
@@ -483,7 +483,7 @@ class Pattern:
 
     def __str__(self):
         if len(self.concs) == 0:
-            raise Exception(f"Can't serialise {repr(self)}")
+            raise Exception(f"Can't serialise {self!r}")
         return "|".join(sorted(str(conc) for conc in self.concs))
 
     def reduce(self) -> Pattern:
@@ -654,7 +654,7 @@ class Pattern:
         If "suffix" is True, the same result but for suffixes.
         """
         if len(self.concs) == 0:
-            raise Exception(f"Can't call _commonconc on {repr(self)}")
+            raise Exception(f"Can't call _commonconc on {self!r}")
 
         return reduce(
             lambda x, y: x.common(y, suffix=suffix),
@@ -804,7 +804,7 @@ class Mult:
         return hash((self.multiplicand, self.multiplier))
 
     def __repr__(self):
-        return f"Mult({repr(self.multiplicand)}, {repr(self.multiplier)})"
+        return f"Mult({self.multiplicand!r}, {self.multiplier!r})"
 
     def dock(self, other):
         """
@@ -815,7 +815,7 @@ class Mult:
         """
         if other.multiplicand != self.multiplicand:
             raise Exception(
-                f"Can't subtract {repr(other)} from {repr(self)}"
+                f"Can't subtract {other!r} from {self!r}"
             )
         return Mult(self.multiplicand, self.multiplier - other.multiplier)
 

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -1,6 +1,6 @@
 '''
-    Because of the circularity between `Pattern`, `Conc` and `Mult`, all three
-    need to be in the same source file?
+Because of the circularity between `Pattern`, `Conc` and `Mult`, all three
+need to be in the same source file?
 '''
 
 from __future__ import annotations
@@ -25,10 +25,10 @@ from .multiplier import ONE, QM, STAR, ZERO, Multiplier
 @dataclass(frozen=True)
 class Conc():
     '''
-        A `Conc` (short for "concatenation") is a tuple of `Mult`s i.e. an
-        unbroken string of mults occurring one after the other.
-        e.g. abcde[^fg]*h{4}[a-z]+(subpattern)(subpattern2)
-        To express the empty string, use an empty `Conc`, Conc().
+    A `Conc` (short for "concatenation") is a tuple of `Mult`s i.e. an
+    unbroken string of mults occurring one after the other.
+    e.g. abcde[^fg]*h{4}[a-z]+(subpattern)(subpattern2)
+    To express the empty string, use an empty `Conc`, Conc().
     '''
 
     mults: tuple[Mult, ...]
@@ -185,17 +185,17 @@ class Conc():
 
     def common(self, other, suffix=False):
         '''
-            Return the common prefix of these two `Conc`s; that is, the largest
-            `Conc` which can be safely beheaded() from the front of both. The
-            result could be `EMPTYSTRING`.
-            "ZYAA, ZYBB" -> "ZY"
-            "CZ, CZ" -> "CZ"
-            "YC, ZC" -> ""
+        Return the common prefix of these two `Conc`s; that is, the largest
+        `Conc` which can be safely beheaded() from the front of both. The
+        result could be `EMPTYSTRING`.
+        "ZYAA, ZYBB" -> "ZY"
+        "CZ, CZ" -> "CZ"
+        "YC, ZC" -> ""
 
-            With the "suffix" flag set, works from the end. E.g.:
-            "AAZY, BBZY" -> "ZY"
-            "CZ, CZ" -> "CZ"
-            "CY, CZ" -> ""
+        With the "suffix" flag set, works from the end. E.g.:
+        "AAZY, BBZY" -> "ZY"
+        "CZ, CZ" -> "CZ"
+        "CY, CZ" -> ""
         '''
         mults = []
 
@@ -231,10 +231,10 @@ class Conc():
 
     def dock(self, other):
         '''
-            Subtract another `Conc` from this one.
-            This is the opposite of concatenation.
-            For example, if ABC + DEF = ABCDEF,
-            then logically ABCDEF - DEF = ABC.
+        Subtract another `Conc` from this one.
+        This is the opposite of concatenation.
+        For example, if ABC + DEF = ABCDEF,
+        then logically ABCDEF - DEF = ABC.
         '''
 
         # e.g. self has mults at indices [0, 1, 2, 3, 4, 5, 6] len=7
@@ -263,8 +263,8 @@ class Conc():
 
     def behead(self, other):
         '''
-            As with dock() but the other way around. For example, if
-            ABC + DEF = ABCDEF, then ABCDEF.behead(AB) = CDEF.
+        As with dock() but the other way around. For example, if
+        ABC + DEF = ABCDEF, then ABCDEF.behead(AB) = CDEF.
         '''
         # Observe that FEDCBA - BA = FEDC.
         return self.reversed().dock(other.reversed()).reversed()
@@ -282,8 +282,8 @@ class _Outside(Enum):
 
 def from_fsm(f: Fsm) -> Pattern:
     '''
-        Turn the supplied finite state machine into a `Pattern`. This is
-        accomplished using the Brzozowski algebraic method.
+    Turn the supplied finite state machine into a `Pattern`. This is
+    accomplished using the Brzozowski algebraic method.
     '''
     # Make sure the supplied alphabet is kosher. It must contain only single-
     # character strings or `ANYTHING_ELSE`.
@@ -399,10 +399,10 @@ def from_fsm(f: Fsm) -> Pattern:
 
 def call_fsm(method):
     '''
-        Take a method which acts on 0 or more regular expression objects...
-        return a new method which simply converts them all to FSMs, calls the
-        FSM method on them instead, then converts the result back to a regular
-        expression. We do this for several of the more annoying operations.
+    Take a method which acts on 0 or more regular expression objects...
+    return a new method which simply converts them all to FSMs, calls the
+    FSM method on them instead, then converts the result back to a regular
+    expression. We do this for several of the more annoying operations.
     '''
     fsm_method = getattr(Fsm, method.__name__)
 
@@ -416,19 +416,19 @@ def call_fsm(method):
 @dataclass(frozen=True)
 class Pattern:
     '''
-        A `Pattern` (also known as an "alt", short for "alternation") is a
-        set of `Conc`s. A `Pattern` expresses multiple alternate possibilities.
-        When written out as a regex, these would separated by pipes. A
-        `Pattern` containing no possibilities is possible and represents a
-        regular expression matching no strings whatsoever (there is no
-        conventional string form for this).
+    A `Pattern` (also known as an "alt", short for "alternation") is a
+    set of `Conc`s. A `Pattern` expresses multiple alternate possibilities.
+    When written out as a regex, these would separated by pipes. A
+    `Pattern` containing no possibilities is possible and represents a
+    regular expression matching no strings whatsoever (there is no
+    conventional string form for this).
 
-        e.g. "abc|def(ghi|jkl)" is an alt containing two `Conc`s: "abc" and
-        "def(ghi|jkl)". The latter is a `Conc` containing four `Mult`s: "d",
-        "e", "f" and "(ghi|jkl)". The latter in turn is a `Mult` consisting of
-        an upper bound 1, a lower bound 1, and a multiplicand which is a new
-        subpattern, "ghi|jkl". This new subpattern again consists of two
-        `Conc`s: "ghi" and "jkl".
+    e.g. "abc|def(ghi|jkl)" is an alt containing two `Conc`s: "abc" and
+    "def(ghi|jkl)". The latter is a `Conc` containing four `Mult`s: "d",
+    "e", "f" and "(ghi|jkl)". The latter in turn is a `Mult` consisting of
+    an upper bound 1, a lower bound 1, and a multiplicand which is a new
+    subpattern, "ghi|jkl". This new subpattern again consists of two
+    `Conc`s: "ghi" and "jkl".
     '''
 
     concs: frozenset[Conc]
@@ -467,8 +467,8 @@ class Pattern:
     @call_fsm
     def difference(*elems):
         '''
-            Return a regular expression which matches any string which `self`
-            matches but none of the strings which `other` matches.
+        Return a regular expression which matches any string which `self`
+        matches but none of the strings which `other` matches.
         '''
         pass
 
@@ -614,8 +614,8 @@ class Pattern:
     @call_fsm
     def symmetric_difference(*elems):
         '''
-            Return a regular expression matching only the strings recognised by
-            `self` or `other` but not both.
+        Return a regular expression matching only the strings recognised by
+        `self` or `other` but not both.
         '''
         pass
 
@@ -624,34 +624,34 @@ class Pattern:
 
     def dock(self, other):
         '''
-            The opposite of concatenation. Remove a common suffix from the
-            present `Pattern`; that is, from each of its constituent concs.
+        The opposite of concatenation. Remove a common suffix from the
+        present `Pattern`; that is, from each of its constituent concs.
 
-            AYZ|BYZ|CYZ - YZ -> A|B|C.
+        AYZ|BYZ|CYZ - YZ -> A|B|C.
         '''
         return Pattern(*[conc.dock(other) for conc in self.concs])
 
     def behead(self, other):
         '''
-            Like dock() but the other way around. Remove a common prefix from
-            the present `Pattern`; that is, from each of its constituent concs.
+        Like dock() but the other way around. Remove a common prefix from
+        the present `Pattern`; that is, from each of its constituent concs.
 
-            ZA|ZB|ZC.behead(Z) -> A|B|C
+        ZA|ZB|ZC.behead(Z) -> A|B|C
         '''
         return Pattern(*[conc.behead(other) for conc in self.concs])
 
     def _commonconc(self, suffix=False):
         '''
-            Find the longest `Conc` which acts as prefix to every `Conc` in
-            this `Pattern`. This could be `EMPTYSTRING`. Return the common
-            prefix along with all the leftovers after truncating that common
-            prefix from each `Conc`.
+        Find the longest `Conc` which acts as prefix to every `Conc` in
+        this `Pattern`. This could be `EMPTYSTRING`. Return the common
+        prefix along with all the leftovers after truncating that common
+        prefix from each `Conc`.
 
-            "ZA|ZB|ZC" -> "Z", "(A|B|C)"
-            "ZA|ZB|ZC|Z" -> "Z", "(A|B|C|)"
-            "CZ|CZ" -> "CZ", "()"
+        "ZA|ZB|ZC" -> "Z", "(A|B|C)"
+        "ZA|ZB|ZC|Z" -> "Z", "(A|B|C|)"
+        "CZ|CZ" -> "CZ", "()"
 
-            If "suffix" is True, the same result but for suffixes.
+        If "suffix" is True, the same result but for suffixes.
         '''
         if len(self.concs) == 0:
             raise Exception(f"Can't call _commonconc on {repr(self)}")
@@ -675,24 +675,24 @@ class Pattern:
 
     def copy(self):
         '''
-            For completeness only, since `set.copy()` also exists. `Pattern`s
-            are immutable, so I can see only very odd reasons to need this
+        For completeness only, since `set.copy()` also exists. `Pattern`s
+        are immutable, so I can see only very odd reasons to need this
         '''
         return Pattern(*self.concs)
 
     def equivalent(self, other):
         '''
-            Two `Pattern`s are equivalent if they recognise the same strings.
-            Note that in the general case this is actually quite an intensive
-            calculation, but far from unsolvable, as we demonstrate here:
+        Two `Pattern`s are equivalent if they recognise the same strings.
+        Note that in the general case this is actually quite an intensive
+        calculation, but far from unsolvable, as we demonstrate here:
         '''
         return self.to_fsm().equivalent(other.to_fsm())
 
     def times(self, multiplier):
         '''
-            Equivalent to repeated concatenation. Multiplier consists of a
-            minimum and a maximum; maximum may be infinite (for Kleene star
-            closure). Call using "a = b * qm"
+        Equivalent to repeated concatenation. Multiplier consists of a
+        minimum and a maximum; maximum may be infinite (for Kleene star
+        closure). Call using "a = b * qm"
         '''
         return Pattern(Conc(Mult(self, multiplier)))
 
@@ -702,11 +702,11 @@ class Pattern:
     @call_fsm
     def everythingbut(self):
         '''
-            Return a `Pattern` which will match any string not matched by
-            `self`, and which will not match any string matched by `self`.
-            Another task which is very difficult in general (and typically
-            returns utter garbage when actually printed), but becomes trivial
-            to code thanks to FSM routines.
+        Return a `Pattern` which will match any string not matched by
+        `self`, and which will not match any string matched by `self`.
+        Another task which is very difficult in general (and typically
+        returns utter garbage when actually printed), but becomes trivial
+        to code thanks to FSM routines.
         '''
         pass
 
@@ -715,8 +715,8 @@ class Pattern:
 
     def isdisjoint(self, other):
         '''
-            Treat `self` and `other` as sets of strings and see if they are
-            disjoint
+        Treat `self` and `other` as sets of strings and see if they are
+        disjoint
         '''
         return self.to_fsm().isdisjoint(other.to_fsm())
 
@@ -725,8 +725,8 @@ class Pattern:
 
     def __contains__(self, string):
         '''
-            This lets you use the syntax `"a" in pattern` to see whether the
-            string "a" is in the set of strings matched by `pattern`.
+        This lets you use the syntax `"a" in pattern` to see whether the
+        string "a" is in the set of strings matched by `pattern`.
         '''
         return self.matches(string)
 
@@ -735,9 +735,9 @@ class Pattern:
 
     def cardinality(self):
         '''
-            Consider the regular expression as a set of strings and return the
-            cardinality of that set, or raise an OverflowError if there are
-            infinitely many.
+        Consider the regular expression as a set of strings and return the
+        cardinality of that set, or raise an OverflowError if there are
+        infinitely many.
         '''
         # There is no way to do this other than converting to an FSM, because
         # the `Pattern` may allow duplicate routes, such as "a|a".
@@ -748,10 +748,10 @@ class Pattern:
 
     def strings(self, otherchar=None):
         '''
-            Each time next() is called on this iterator, a new string is
-            returned which this `Pattern` can match. `StopIteration`
-            is raised once all such strings have been returned, although a
-            regex with a * in may match infinitely many strings.
+        Each time next() is called on this iterator, a new string is
+        returned which this `Pattern` can match. `StopIteration`
+        is raised once all such strings have been returned, although a
+        regex with a * in may match infinitely many strings.
         '''
 
         # In the case of a regex like "[^abc]", there are infinitely many
@@ -774,8 +774,8 @@ class Pattern:
 
     def __iter__(self):
         '''
-            This allows you to do `for string in pattern` as a list
-            comprehension!
+        This allows you to do `for string in pattern` as a list
+        comprehension!
         '''
         return self.strings()
 
@@ -783,13 +783,13 @@ class Pattern:
 @dataclass(frozen=True)
 class Mult:
     '''
-        A `Mult` is a combination of a multiplicand with a multiplier (a min
-        and a max). The vast majority of characters in regular expressions
-        occur without a specific multiplier, which is implicitly equivalent to
-        a min of 1 and a max of 1, but many more have explicit multipliers like
-        "*" (min = 0, max = INF) and so on.
+    A `Mult` is a combination of a multiplicand with a multiplier (a min
+    and a max). The vast majority of characters in regular expressions
+    occur without a specific multiplier, which is implicitly equivalent to
+    a min of 1 and a max of 1, but many more have explicit multipliers like
+    "*" (min = 0, max = INF) and so on.
 
-        e.g. a, b{2}, c?, d*, [efg]{2,5}, f{2,}, (anysubpattern)+, .*, ...
+    e.g. a, b{2}, c?, d*, [efg]{2,5}, f{2,}, (anysubpattern)+, .*, ...
     '''
 
     multiplicand: Charclass | Pattern
@@ -808,10 +808,10 @@ class Mult:
 
     def dock(self, other):
         '''
-            "Dock" another `Mult` from this one (i.e. remove part of the tail)
-            and return the result. The reverse of concatenation. This is a lot
-            trickier.
-            e.g. a{4,5} - a{3} = a{1,2}
+        "Dock" another `Mult` from this one (i.e. remove part of the tail)
+        and return the result. The reverse of concatenation. This is a lot
+        trickier.
+        e.g. a{4,5} - a{3} = a{1,2}
         '''
         if other.multiplicand != self.multiplicand:
             raise Exception(
@@ -821,10 +821,10 @@ class Mult:
 
     def common(self, other):
         '''
-            Return the common part of these two mults. This is the largest
-            `Mult` which can be safely subtracted from both the originals. The
-            multiplier on this `Mult` could be `ZERO`: this is the case if, for
-            example, the multiplicands disagree.
+        Return the common part of these two mults. This is the largest
+        `Mult` which can be safely subtracted from both the originals. The
+        multiplier on this `Mult` could be `ZERO`: this is the case if, for
+        example, the multiplicands disagree.
         '''
         if self.multiplicand == other.multiplicand:
             return Mult(

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -126,9 +126,9 @@ class Conc():
                             rm_pattern,
                             Multiplier(r.multiplier.min, r.multiplier.min)
                         )
-                        new = self.mults[:i] + \
-                            (trimmed, s) + \
-                            self.mults[i + 2:]
+                        new = self.mults[:i] \
+                            + (trimmed, s) \
+                            + self.mults[i + 2:]
                         return Conc(*new).reduce()
 
                 # Conversely, if R is superset of S, then R{c,}S{a,b} reduces
@@ -144,9 +144,9 @@ class Conc():
                             sm_pattern,
                             Multiplier(s.multiplier.min, s.multiplier.min)
                         )
-                        new = self.mults[:i] + \
-                            (r, trimmed) + \
-                            self.mults[i + 2:]
+                        new = self.mults[:i] \
+                            + (r, trimmed) \
+                            + self.mults[i + 2:]
                         return Conc(*new).reduce()
 
         # Conc contains (among other things) a *singleton* `Mult` containing
@@ -537,10 +537,10 @@ class Pattern:
                     continue
                 multiplier = multiplier1 | multiplier2
                 newconcs = \
-                    oldconcs[:i] + \
-                    oldconcs[i + 1:j] + \
-                    oldconcs[j + 1:] + \
-                    [Conc(Mult(multiplicand, multiplier))]
+                    oldconcs[:i] \
+                    + oldconcs[i + 1:j] \
+                    + oldconcs[j + 1:] \
+                    + [Conc(Mult(multiplicand, multiplier))]
                 return Pattern(*newconcs).reduce()
 
         # If this `Pattern` contains several `Conc`s each containing just 1

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -418,8 +418,8 @@ def test_base_N():
                 (
                     "initial",
                     dict(
-                        [(str(j), j % N) for j in range(1, base)] +
-                        [("0", "zero")]
+                        [(str(j), j % N) for j in range(1, base)]
+                        + [("0", "zero")]
                     )
                 ),
                 (
@@ -720,9 +720,9 @@ def test_parse_regex_intersection():
     assert str(parse("[a-g0-8$%\\^]+") & parse("[^d]{2,8}")) == \
         "[$%0-8\\^abcefg]{2,8}"
     assert str(
-        parse("\\W*") &
-        parse("[a-g0-8$%\\^]+") &
-        parse("[^d]{2,8}")
+        parse("\\W*")
+        & parse("[a-g0-8$%\\^]+")
+        & parse("[^d]{2,8}")
     ) == \
         "[$%\\^]{2,8}"
     assert str(parse("\\d{4}-\\d{2}-\\d{2}") & parse("19.*")) == \

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -646,16 +646,16 @@ def test_reduce_concatenations():
 
 
 def test_mult_multiplication():
-    assert parse("(a{2,3}){1,1}").reduce() == \
-        parse("a{2,3}").reduce()
-    assert parse("(a{2,3}){1}").reduce() == \
-        parse("a{2,3}").reduce()
-    assert parse("(a{2,3})").reduce() == \
-        parse("a{2,3}").reduce()
-    assert parse("(a{2,3}){4,5}").reduce() == \
-        parse("a{8,15}").reduce()
-    assert parse("(a{2,}){2,}").reduce() == \
-        parse("a{4,}").reduce()
+    assert parse("(a{2,3}){1,1}").reduce() \
+        == parse("a{2,3}").reduce()
+    assert parse("(a{2,3}){1}").reduce() \
+        == parse("a{2,3}").reduce()
+    assert parse("(a{2,3})").reduce() \
+        == parse("a{2,3}").reduce()
+    assert parse("(a{2,3}){4,5}").reduce() \
+        == parse("a{8,15}").reduce()
+    assert parse("(a{2,}){2,}").reduce() \
+        == parse("a{4,}").reduce()
 
 
 def test_even_star_bug2():
@@ -707,26 +707,25 @@ def test_parse_regex_intersection():
     assert parse("[ab]{0,2}").matches("")
     assert parse("[^a]{0,2}").matches("")
     assert parse("b{0,2}").matches("")
-    assert str(parse("[ab]{0,2}") & parse("[^a]{0,2}")) == \
-        "b{0,2}"
-    assert str(parse("[ab]{0,4}") & parse("[^a]{0,4}")) == \
-        "b{0,4}"
-    assert str(parse("[abc]{0,8}") & parse("[^a]{0,8}")) == \
-        "[bc]{0,8}"
-    assert str(parse("[a-g0-8$%\\^]{0,8}") & parse("[^d]{0,8}")) == \
-        "[$%0-8\\^abcefg]{0,8}"
-    assert str(parse("[a-g0-8$%\\^]+") & parse("[^d]{0,8}")) == \
-        "[$%0-8\\^abcefg]{1,8}"
-    assert str(parse("[a-g0-8$%\\^]+") & parse("[^d]{2,8}")) == \
-        "[$%0-8\\^abcefg]{2,8}"
+    assert str(parse("[ab]{0,2}") & parse("[^a]{0,2}")) \
+        == "b{0,2}"
+    assert str(parse("[ab]{0,4}") & parse("[^a]{0,4}")) \
+        == "b{0,4}"
+    assert str(parse("[abc]{0,8}") & parse("[^a]{0,8}")) \
+        == "[bc]{0,8}"
+    assert str(parse("[a-g0-8$%\\^]{0,8}") & parse("[^d]{0,8}")) \
+        == "[$%0-8\\^abcefg]{0,8}"
+    assert str(parse("[a-g0-8$%\\^]+") & parse("[^d]{0,8}")) \
+        == "[$%0-8\\^abcefg]{1,8}"
+    assert str(parse("[a-g0-8$%\\^]+") & parse("[^d]{2,8}")) \
+        == "[$%0-8\\^abcefg]{2,8}"
     assert str(
         parse("\\W*")
         & parse("[a-g0-8$%\\^]+")
         & parse("[^d]{2,8}")
-    ) == \
-        "[$%\\^]{2,8}"
-    assert str(parse("\\d{4}-\\d{2}-\\d{2}") & parse("19.*")) == \
-        "19\\d{2}-\\d{2}-\\d{2}"
+    ) == "[$%\\^]{2,8}"
+    assert str(parse("\\d{4}-\\d{2}-\\d{2}") & parse("19.*")) \
+        == "19\\d{2}-\\d{2}-\\d{2}"
 
 
 def test_complexify():
@@ -752,10 +751,10 @@ def test_silly_reduction():
     # This one is horrendous and we have to jump through some hoops to get to
     # a sensible result. Probably not a good unit test actually.
     long = \
-        "(aa|bb*aa)a*|((ab|bb*ab)|(aa|bb*aa)a*b)" + \
-        "((ab|bb*ab)|(aa|bb*aa)a*b)*" + \
-        "(aa|bb*aa)a*|((ab|bb*ab)|(aa|bb*aa)a*b)" + \
-        "((ab|bb*ab)|(aa|bb*aa)a*b)*"
+        "(aa|bb*aa)a*|((ab|bb*ab)|(aa|bb*aa)a*b)" \
+        + "((ab|bb*ab)|(aa|bb*aa)a*b)*" \
+        + "(aa|bb*aa)a*|((ab|bb*ab)|(aa|bb*aa)a*b)" \
+        + "((ab|bb*ab)|(aa|bb*aa)a*b)*"
     long = parse(long)
     long = long.to_fsm().reversed()
     long = from_fsm(long).reversed()
@@ -830,26 +829,26 @@ def test_obvious_reduction():
 
 def test_mult_squoosh():
     # sequence squooshing of mults within a `Conc`
-    assert str(parse("[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]").reduce()) == \
-        "[0-9A-Fa-f]{3}"
-    assert str(parse("[$%\\^]?[$%\\^]").reduce()) == \
-        "[$%\\^]{1,2}"
+    assert str(parse("[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]").reduce()) \
+        == "[0-9A-Fa-f]{3}"
+    assert str(parse("[$%\\^]?[$%\\^]").reduce()) \
+        == "[$%\\^]{1,2}"
     assert str(parse(
         "(|(|(|(|(|[$%\\^])[$%\\^])[$%\\^])[$%\\^])[$%\\^])[$%\\^][$%\\^]"
-    ).reduce()) == \
-        "[$%\\^]{2,7}"
+    ).reduce()) \
+        == "[$%\\^]{2,7}"
 
 
 def test_bad_reduction_bug():
     # DEFECT: "0{2}|1{2}" was erroneously reduced() to "[01]{2}"
-    assert parse("0{2}|1{2}").reduce() != \
-        parse("[01]{2}")
-    assert parse("0|[1-9]|ab").reduce() == \
-        parse("\\d|ab")
-    assert parse("0|[1-9]|a{5,7}").reduce() == \
-        parse("\\d|a{5,7}")
-    assert parse("0|(0|[1-9]|a{5,7})").reduce() == \
-        parse("0|(\\d|a{5,7})")
+    assert parse("0{2}|1{2}").reduce() \
+        != parse("[01]{2}")
+    assert parse("0|[1-9]|ab").reduce() \
+        == parse("\\d|ab")
+    assert parse("0|[1-9]|a{5,7}").reduce() \
+        == parse("\\d|a{5,7}")
+    assert parse("0|(0|[1-9]|a{5,7})").reduce() \
+        == parse("0|(\\d|a{5,7})")
     # TODO: should do better than this! Merge that 0
 
 
@@ -868,8 +867,8 @@ def test_epsilon_reduction():
 
 
 def test_charclass_intersection_2():
-    assert (parse("[A-z]") & parse("[^g]")).reduce() == \
-        parse("[A-fh-z]").reduce()
+    assert (parse("[A-z]") & parse("[^g]")).reduce() \
+        == parse("[A-fh-z]").reduce()
 
 
 def test_reduce_boom():
@@ -888,26 +887,26 @@ def test_new_reduce():
 
 
 def test_main_bug():
-    assert str(parse("a*").reduce()) == \
-        "a*"
-    assert str(parse("a|a*").reduce()) == \
-        "a*"
-    assert str(parse("a{1,2}|a{3,4}|bc").reduce()) == \
-        "a{1,4}|bc"
-    assert str(parse("a{1,2}|bc|a{3,4}").reduce()) == \
-        "a{1,4}|bc"
-    assert str(parse("a{1,2}|a{3,4}|a{5,6}|bc").reduce()) == \
-        "a{1,6}|bc"
-    assert str(parse("a{1,2}|a{3}|a{5,6}").reduce()) == \
-        "a{1,2}(a?|a{4})"
-    assert str(parse("a{1,2}|a{3}|a{5,6}|bc").reduce()) == \
-        "a{1,3}|a{5,6}|bc"
-    assert str(parse("a{1,2}|a{4}|a{5,6}").reduce()) == \
-        "a{1,2}(a{3,4})?"
-    assert str(parse("a{1,2}|a{4}|a{5,6}|bc").reduce()) == \
-        "a{1,2}|a{4,6}|bc"
-    assert str((parse("a") | parse("a*")).reduce()) == \
-        "a*"
+    assert str(parse("a*").reduce()) \
+        == "a*"
+    assert str(parse("a|a*").reduce()) \
+        == "a*"
+    assert str(parse("a{1,2}|a{3,4}|bc").reduce()) \
+        == "a{1,4}|bc"
+    assert str(parse("a{1,2}|bc|a{3,4}").reduce()) \
+        == "a{1,4}|bc"
+    assert str(parse("a{1,2}|a{3,4}|a{5,6}|bc").reduce()) \
+        == "a{1,6}|bc"
+    assert str(parse("a{1,2}|a{3}|a{5,6}").reduce()) \
+        == "a{1,2}(a?|a{4})"
+    assert str(parse("a{1,2}|a{3}|a{5,6}|bc").reduce()) \
+        == "a{1,3}|a{5,6}|bc"
+    assert str(parse("a{1,2}|a{4}|a{5,6}").reduce()) \
+        == "a{1,2}(a{3,4})?"
+    assert str(parse("a{1,2}|a{4}|a{5,6}|bc").reduce()) \
+        == "a{1,2}|a{4,6}|bc"
+    assert str((parse("a") | parse("a*")).reduce()) \
+        == "a*"
 
 
 def test_bug_28_b():

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -480,10 +480,10 @@ def test_dead_default():
         initial=0,
         finals={4},
         map={
-                0: {"/": 1},
-                1: {"*": 2},
-                2: {"/": 2, ANYTHING_ELSE: 2, "*": 3},
-                3: {"/": 4, ANYTHING_ELSE: 2, "*": 3},
+            0: {"/": 1},
+            1: {"*": 2},
+            2: {"/": 2, ANYTHING_ELSE: 2, "*": 3},
+            3: {"/": 4, ANYTHING_ELSE: 2, "*": 3},
         }
     ))
     assert str(blockquote) == "/\\*([^*]|\\*+[^*/])*\\*+/"

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -294,13 +294,13 @@ def test_dot():
 def test_abstar():
     # Buggggs.
     abstar = Fsm(
-        alphabet={'a', ANYTHING_ELSE, 'b'},
+        alphabet={"a", ANYTHING_ELSE, "b"},
         states={0, 1},
         initial=0,
         finals={0},
         map={
-            0: {'a': 0, ANYTHING_ELSE: 1, 'b': 0},
-            1: {'a': 1, ANYTHING_ELSE: 1, 'b': 1}
+            0: {"a": 0, ANYTHING_ELSE: 1, "b": 0},
+            1: {"a": 1, ANYTHING_ELSE: 1, "b": 1}
         }
     )
     assert str(from_fsm(abstar)) == "[ab]*"
@@ -308,16 +308,16 @@ def test_abstar():
 
 def test_adotb():
     adotb = Fsm(
-        alphabet={'a', ANYTHING_ELSE, 'b'},
+        alphabet={"a", ANYTHING_ELSE, "b"},
         states={0, 1, 2, 3, 4},
         initial=0,
         finals={4},
         map={
-            0: {'a': 2, ANYTHING_ELSE: 1, 'b': 1},
-            1: {'a': 1, ANYTHING_ELSE: 1, 'b': 1},
-            2: {'a': 3, ANYTHING_ELSE: 3, 'b': 3},
-            3: {'a': 1, ANYTHING_ELSE: 1, 'b': 4},
-            4: {'a': 1, ANYTHING_ELSE: 1, 'b': 1}
+            0: {"a": 2, ANYTHING_ELSE: 1, "b": 1},
+            1: {"a": 1, ANYTHING_ELSE: 1, "b": 1},
+            2: {"a": 3, ANYTHING_ELSE: 3, "b": 3},
+            3: {"a": 1, ANYTHING_ELSE: 1, "b": 4},
+            4: {"a": 1, ANYTHING_ELSE: 1, "b": 1}
         }
     )
     assert str(from_fsm(adotb)) == "a.b"
@@ -950,33 +950,33 @@ def test_isdisjoint():
 def test_bug_slow():
     # issue #43
     m = Fsm(
-        alphabet={'R', 'L', 'U', 'D'},
+        alphabet={"R", "L", "U", "D"},
         states={
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
             11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
         initial=0,
         finals={20},
         map={
-            0: {'D': 1, 'U': 2},
-            1: {'L': 3},
-            2: {'L': 4},
-            3: {'U': 5},
-            4: {'D': 6},
-            5: {'R': 7},
-            6: {'R': 8},
-            7: {'U': 9},
-            8: {'D': 10},
-            9: {'L': 11},
-            10: {'L': 12},
-            11: {'L': 13},
-            12: {'L': 14},
-            13: {'D': 15},
-            14: {'U': 16},
-            15: {'R': 17},
-            16: {'R': 18},
-            17: {'D': 19},
-            18: {'U': 19},
-            19: {'L': 20},
+            0: {"D": 1, "U": 2},
+            1: {"L": 3},
+            2: {"L": 4},
+            3: {"U": 5},
+            4: {"D": 6},
+            5: {"R": 7},
+            6: {"R": 8},
+            7: {"U": 9},
+            8: {"D": 10},
+            9: {"L": 11},
+            10: {"L": 12},
+            11: {"L": 13},
+            12: {"L": 14},
+            13: {"D": 15},
+            14: {"U": 16},
+            15: {"R": 17},
+            16: {"R": 18},
+            17: {"D": 19},
+            18: {"U": 19},
+            19: {"L": 20},
             20: {}
         }
     )
@@ -989,21 +989,21 @@ def test_bug_slow():
 
 def test_bug_48_simpler():
     assert str(from_fsm(Fsm(
-        alphabet={'d'},
+        alphabet={"d"},
         states={0, 1},
         initial=0,
         finals={1},
         map={
-            0: {'d': 1},
+            0: {"d": 1},
         },
-    ))) == 'd'
+    ))) == "d"
 
 
 def test_bug_48():
     S5, S26, S45, S63, S80, S97, S113, S127, S140, S152, S163, S175, S182 = \
         range(13)
     char0, char1, char2, char3, char4, char5, char6, char7, char8 = \
-        '_', 'a', 'd', 'e', 'g', 'm', 'n', 'o', 'p'
+        "_", "a", "d", "e", "g", "m", "n", "o", "p"
 
     machine = Fsm(
         alphabet={
@@ -1033,7 +1033,7 @@ def test_bug_48():
     )
 
     rex = from_fsm(machine)
-    assert str(rex) == 'damage_on_mp'
+    assert str(rex) == "damage_on_mp"
 
 
 def test_pickle():

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -19,6 +19,7 @@ if __name__ == "__main__":
 ###############################################################################
 # Stringification tests
 
+
 def test_charclass_str():
     # Arbitrary ranges
     assert str(parse("[\\w:;<=>?@\\[\\\\\\]\\^`]")) == "[0-z]"
@@ -40,6 +41,7 @@ def test_parse_str_round_trip():
 
 ###############################################################################
 # Test to_fsm() and alphabet-related functionality
+
 
 def test_alphabet():
     # `.alphabet()` should include `ANYTHING_ELSE`
@@ -110,6 +112,7 @@ def test_bug_28():
 ###############################################################################
 # Test matches(). Quite sparse at the moment
 
+
 def test_wildcards_in_charclasses():
     # Allow "\w", "\d" and "\s" in `Charclass`es
     assert parse("[\\w~]*").matches("a0~")
@@ -149,6 +152,7 @@ def test_in():
 
 ###############################################################################
 # Test string generators
+
 
 def test_charclass_gen():
     gen = parse("[xyz]").strings()
@@ -257,6 +261,7 @@ def test_forin():
 ###############################################################################
 # Test cardinality() and len()
 
+
 def test_cardinality():
     assert parse("[]").cardinality() == 0
     assert parse("[]?").cardinality() == 1
@@ -271,6 +276,7 @@ def test_cardinality():
 
 ###############################################################################
 
+
 def test_copy():
     x = parse("abc|def(ghi|jkl)")
     assert x.copy() == x
@@ -278,6 +284,7 @@ def test_copy():
 
 ###############################################################################
 # Test from_fsm()
+
 
 def test_dot():
     # not "a[ab]b"
@@ -485,6 +492,7 @@ def test_dead_default():
 ###############################################################################
 # charclass set operations
 
+
 def test_charclass_union():
     assert (parse("[ab]") | parse("[bc]")).reduce() == parse("[abc]")
     assert (parse("[ab]") | parse("[^bc]")).reduce() == parse("[^c]")
@@ -502,6 +510,7 @@ def test_charclass_intersection():
 ###############################################################################
 # Emptiness detection
 
+
 def test_empty():
     assert not parse("a{0}").empty()
     assert parse("[]").empty()
@@ -514,6 +523,7 @@ def test_empty():
 
 ###############################################################################
 # Test everythingbut()
+
 
 def test_everythingbut():
     # Regexes are usually gibberish but we make a few claims
@@ -549,6 +559,7 @@ def test_isinstance_bug():
 
 ###############################################################################
 
+
 def test_equivalence():
     assert parse("aa*").equivalent(parse("a*a"))
     assert parse("([ab]*a|[bc]*c)?b*").equivalent(parse("b*(a[ab]*|c[bc]*)?"))
@@ -556,6 +567,7 @@ def test_equivalence():
 
 ###############################################################################
 # Test reversed()
+
 
 def test_regex_reversal():
     assert parse("b").reversed() == parse("b")
@@ -569,6 +581,7 @@ def test_regex_reversal():
 ###############################################################################
 # Tests for some more set operations
 
+
 def test_set_ops():
     assert parse("[abcd]") - parse("a") == parse("[bcd]")
     assert parse("[abcd]") ^ parse("[cdef]") == parse("[abef]")
@@ -576,6 +589,7 @@ def test_set_ops():
 
 ###############################################################################
 # Test methods for finding common parts of regular expressions.
+
 
 def test_pattern_commonconc():
     assert str(parse("aa|aa")._commonconc()) == "aa"
@@ -597,6 +611,7 @@ def test_pattern_commonconc_suffix():
 
 ###############################################################################
 # Basic concatenation reduction tests
+
 
 def test_reduce_concatenations():
     assert str(parse("aa").reduce()) == "a{2}"
@@ -629,6 +644,7 @@ def test_reduce_concatenations():
 ###############################################################################
 # Multiplication tests
 
+
 def test_mult_multiplication():
     assert parse("(a{2,3}){1,1}").reduce() == \
         parse("a{2,3}").reduce()
@@ -657,6 +673,7 @@ def test_two_two_bug():
 
 ###############################################################################
 # Test intersection (&)
+
 
 def test_mult_intersection():
     assert str(parse("a") & parse("a")) == "a"
@@ -749,6 +766,7 @@ def test_silly_reduction():
 
 ###############################################################################
 # reduce() tests
+
 
 def test_mult_reduction_easy():
     assert str(parse("a").reduce()) == "a"


### PR DESCRIPTION
NOTE: #80 is based on this branch, and if that merges, this will auto-close.

This consistent-ifies some of the formatting with typical Python styling, incrementally fixing each of the `flake8`/`pycodestyle` warnings until none are left, passing with "all rules on".
(The one remaining suppression of `W503` is disabled-by-default and is required to be disabled for subsequent `black` autoformatting).

This is a lead-in to https://github.com/qntm/greenery/compare/main...rwe:greenery:black which builds on this to introduce fully-automated formatting and https://github.com/qntm/greenery/compare/main...rwe:greenery:pylint which introduces stricter `pylint` linting.

With one small exception, this PR touches only formatting and not logic, structure, or names.
The small exception is this change:
```diff
- f"Could not parse '{string}' beyond index {str(i)}"
+ f"Could not parse {string!r} beyond index {i}"
```
which, via the `!r` → `repr` format specifier, now escapes strings as `'foo\nbar'` for a string containing a newline, versus previously including such characters in the message literally.