### PR TITLE
ci: integrate black auto-formatter

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,9 @@
 [flake8]
 max-line-length = 88
 ignore =
+  # "black" formatter has slightly different operator spacing rules than
+  # flake8's defaults.
+  # whitespace before ‘,’, ‘;’, or ‘:’
+  E203,
   # line break before binary operator
   W503,

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 80
+max-line-length = 88
 ignore =
   # line break before binary operator
   W503,

--- a/.github/workflows/workflow-1.yml
+++ b/.github/workflows/workflow-1.yml
@@ -22,11 +22,14 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest mypy isort
+        pip install flake8 pytest mypy isort black
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with isort
       run: |
         isort --quiet --diff --check .
+    - name: Check formatting with black
+      run: |
+        black --diff --check .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Special `Bound` representing no limit. Can be used as an upper bound only.
 
 ```sh
 isort .
+black .
 mypy greenery
 flake8 --count --statistics --show-source --select=E9,F63,F7,F82 .
 flake8 --count --statistics --exit-zero --max-complexity=10 .

--- a/greenery/bound.py
+++ b/greenery/bound.py
@@ -66,9 +66,7 @@ class Bound:
         """
         if other.v is None:
             if self.v is not None:
-                raise Exception(
-                    f"Can't subtract {other!r} from {self!r}"
-                )
+                raise Exception(f"Can't subtract {other!r} from {self!r}")
 
             # Infinity minus infinity is zero. This has to be true so that
             # we can for example subtract Multiplier(Bound(0), INF) from

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -155,10 +155,8 @@ class Charclass:
         # look for ranges
         currentRange = ""
         for char in sorted(self.chars, key=ord):
-
             # range is not empty: new char must fit after previous one
             if len(currentRange) > 0:
-
                 i = ord(char)
 
                 # char doesn't fit old range: restart

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -47,9 +47,11 @@ class Charclass:
         object.__setattr__(self, "negated", negated)
 
     def __eq__(self, other: object, /) -> bool:
-        return isinstance(other, Charclass) \
-            and self.chars == other.chars \
+        return (
+            isinstance(other, Charclass)
+            and self.chars == other.chars
             and self.negated == other.negated
+        )
 
     def __hash__(self, /) -> int:
         return hash((self.chars, self.negated))

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -141,11 +141,7 @@ class Charclass:
                 # "ab" or "abc" or "abcd"
                 "".join(escapeChar(char) for char in currentRange),
                 # "a-b" or "a-c" or "a-d"
-                (
-                    escapeChar(currentRange[0])
-                    + "-"
-                    + escapeChar(currentRange[-1])
-                ),
+                (escapeChar(currentRange[0]) + "-" + escapeChar(currentRange[-1])),
             ]
             return sorted(strs, key=lambda str: len(str))[0]
 
@@ -213,9 +209,7 @@ class Charclass:
         if self.negated is True:
             string += "~"
         string += "Charclass("
-        string += repr("".join(
-            str(char) for char in sorted(self.chars, key=str)
-        ))
+        string += repr("".join(str(char) for char in sorted(self.chars, key=str)))
         string += ")"
         return string
 
@@ -261,9 +255,7 @@ class Charclass:
 
 
 # Standard character classes
-WORDCHAR = Charclass(
-    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz"
-)
+WORDCHAR = Charclass("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz")
 DIGIT = Charclass("0123456789")
 SPACECHAR = Charclass("\t\n\v\f\r ")
 

--- a/greenery/charclass_test.py
+++ b/greenery/charclass_test.py
@@ -65,9 +65,14 @@ def test_charclass_str() -> None:
     assert str(Charclass("\t\v\r A")) == "[\\t\\v\\r A]"
     assert str(Charclass("\n\f A")) == "[\\n\\f A]"
     assert str(Charclass("\t\n\v\f\r A")) == "[\\t-\\r A]"
-    assert str(Charclass(
-        "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz|"
-    )) == "[0-9A-Z_a-z|]"
+    assert (
+        str(
+            Charclass(
+                "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz|"
+            )
+        )
+        == "[0-9A-Z_a-z|]"
+    )
     assert str(NONWORDCHAR) == "\\W"
     assert str(NONDIGITCHAR) == "\\D"
     assert str(NONSPACECHAR) == "\\S"

--- a/greenery/charclass_test.py
+++ b/greenery/charclass_test.py
@@ -83,11 +83,9 @@ def test_charclass_fsm() -> None:
     # "[^a]"
     nota = (~Charclass("a")).to_fsm()
     assert nota.alphabet == {"a", ANYTHING_ELSE}
-
-    # Fsm methods are not yet typed.
-    assert nota.accepts("b")  # type: ignore
-    assert nota.accepts(["b"])  # type: ignore
-    assert nota.accepts([ANYTHING_ELSE])  # type: ignore
+    assert nota.accepts("b")
+    assert nota.accepts(["b"])
+    assert nota.accepts([ANYTHING_ELSE])
 
 
 def test_charclass_negation() -> None:

--- a/greenery/conc_test.py
+++ b/greenery/conc_test.py
@@ -16,10 +16,7 @@ def test_conc_equality():
     assert a == Conc(Mult(Charclass("a"), ONE))
     assert a != Conc(Mult(Charclass("b"), ONE))
     assert a != Conc(Mult(Charclass("a"), QM))
-    assert a != Conc(Mult(
-        Charclass("a"),
-        Multiplier(Bound(1), Bound(2)))
-    )
+    assert a != Conc(Mult(Charclass("a"), Multiplier(Bound(1), Bound(2))))
     assert a != Conc()
 
 
@@ -70,7 +67,4 @@ def test_conc_dock():
 
 
 def test_mult_reduction_easy():
-    assert Conc(Mult(
-        Charclass("a"),
-        ZERO
-    )).reduce() == Conc()
+    assert Conc(Mult(Charclass("a"), ZERO)).reduce() == Conc()

--- a/greenery/conc_test.py
+++ b/greenery/conc_test.py
@@ -21,16 +21,21 @@ def test_conc_equality():
 
 
 def test_conc_str():
-    assert str(Conc(
-        Mult(Charclass("a"), ONE),
-        Mult(Charclass("b"), ONE),
-        Mult(Charclass("c"), ONE),
-        Mult(Charclass("d"), ONE),
-        Mult(Charclass("e"), ONE),
-        Mult(~Charclass("fg"), STAR),
-        Mult(Charclass("h"), Multiplier(Bound(5), Bound(5))),
-        Mult(Charclass("abcdefghijklmnopqrstuvwxyz"), PLUS),
-    )) == "abcde[^fg]*h{5}[a-z]+"
+    assert (
+        str(
+            Conc(
+                Mult(Charclass("a"), ONE),
+                Mult(Charclass("b"), ONE),
+                Mult(Charclass("c"), ONE),
+                Mult(Charclass("d"), ONE),
+                Mult(Charclass("e"), ONE),
+                Mult(~Charclass("fg"), STAR),
+                Mult(Charclass("h"), Multiplier(Bound(5), Bound(5))),
+                Mult(Charclass("abcdefghijklmnopqrstuvwxyz"), PLUS),
+            )
+        )
+        == "abcde[^fg]*h{5}[a-z]+"
+    )
 
 
 def test_conc_common():

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -296,7 +296,7 @@ class Fsm:
 
         def final(state: frozenset[tuple[int, state_type]]) -> bool:
             """If you're in a final state of the final FSM, it's final"""
-            for (i, substate) in state:
+            for i, substate in state:
                 if i == len(fsms) - 1 and substate in fsms[i].finals:
                     return True
             return False
@@ -312,7 +312,7 @@ class Fsm:
             metastates?
             """
             next: set[tuple[int, state_type]] = set()
-            for (i, substate) in current:
+            for i, substate in current:
                 fsm = fsms[i]
                 if substate in fsm.map:
                     if symbol in fsm.map[substate]:
@@ -395,7 +395,7 @@ class Fsm:
             If the initial state is final then multiplying doesn't alter
             that
             """
-            for (substate, iteration) in state:
+            for substate, iteration in state:
                 if substate == self.initial \
                    and (
                        self.initial in self.finals
@@ -409,7 +409,7 @@ class Fsm:
             symbol: alpha_type,
         ) -> Collection[tuple[state_type, int]]:
             next = []
-            for (substate, iteration) in current:
+            for substate, iteration in current:
                 if iteration < multiplier \
                    and substate in self.map \
                    and symbol in self.map[substate]:
@@ -612,7 +612,7 @@ class Fsm:
         # Fixed point calculation
         i = 0
         while i < len(strings):
-            (cstring, cstate) = strings[i]
+            cstring, cstate = strings[i]
             if cstate in self.map:
                 for symbol in sorted(self.map[cstate]):
                     nstate = self.map[cstate][symbol]
@@ -871,7 +871,7 @@ def parallel(
     alphabet = set().union(*[fsm.alphabet for fsm in fsms])
 
     initial: Mapping[int, state_type] = dict(
-        [(i, fsm.initial) for (i, fsm) in enumerate(fsms)])
+        [(i, fsm.initial) for i, fsm in enumerate(fsms)])
 
     # dedicated function accepts a "superset" and returns the next "superset"
     # obtained by following this transition in the new FSM
@@ -900,7 +900,7 @@ def parallel(
     def final(state: Mapping[int, state_type]) -> bool:
         accepts = [
             i in state and state[i] in fsm.finals
-            for (i, fsm) in enumerate(fsms)
+            for i, fsm in enumerate(fsms)
         ]
         return test(accepts)
 

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -268,7 +268,10 @@ class Fsm:
         """
         alphabet = set().union(*[fsm.alphabet for fsm in fsms])
 
-        def connect_all(i: int, substate: state_type) -> Iterable[tuple[int, state_type]]:
+        def connect_all(
+            i: int,
+            substate: state_type,
+        ) -> Iterable[tuple[int, state_type]]:
             """
             Take a state in the numbered FSM and return a set containing
             it, plus (if it's final) the first state from the next FSM,

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -362,9 +362,11 @@ class Fsm:
 
                 # If one of our substates is final, then we can also consider
                 # transitions from the initial state of the original FSM.
-                if substate in self.finals \
-                   and self.initial in self.map \
-                   and symbol in self.map[self.initial]:
+                if (
+                    substate in self.finals
+                    and self.initial in self.map
+                    and symbol in self.map[self.initial]
+                ):
                     next.add(self.map[self.initial][symbol])
 
             if len(next) == 0:
@@ -395,10 +397,9 @@ class Fsm:
             that
             """
             for substate, iteration in state:
-                if substate == self.initial \
-                   and (
-                       self.initial in self.finals or iteration == multiplier
-                   ):
+                if substate == self.initial and (
+                    self.initial in self.finals or iteration == multiplier
+                ):
                     return True
             return False
 
@@ -408,9 +409,11 @@ class Fsm:
         ) -> Collection[tuple[state_type, int]]:
             next = []
             for substate, iteration in current:
-                if iteration < multiplier \
-                   and substate in self.map \
-                   and symbol in self.map[substate]:
+                if (
+                    iteration < multiplier
+                    and substate in self.map
+                    and symbol in self.map[substate]
+                ):
                     next.append((self.map[substate][symbol], iteration))
                     # final of self? merge with initial on next iteration
                     if self.map[substate][symbol] in self.finals:
@@ -495,9 +498,11 @@ class Fsm:
             symbol: alpha_type,
         ) -> Mapping[int, state_type]:
             next = {}
-            if 0 in current \
-               and current[0] in self.map \
-               and symbol in self.map[current[0]]:
+            if (
+                0 in current
+                and current[0] in self.map
+                and symbol in self.map[current[0]]
+            ):
                 next[0] = self.map[current[0]][symbol]
             return next
 
@@ -880,14 +885,18 @@ def parallel(
         next = {}
         for i in range(len(fsms)):
             actual_symbol: alpha_type
-            if symbol not in fsms[i].alphabet \
-               and ANYTHING_ELSE in fsms[i].alphabet:
+            if (
+                symbol not in fsms[i].alphabet
+                and ANYTHING_ELSE in fsms[i].alphabet
+            ):
                 actual_symbol = ANYTHING_ELSE
             else:
                 actual_symbol = symbol
-            if i in current \
-               and current[i] in fsms[i].map \
-               and actual_symbol in fsms[i].map[current[i]]:
+            if (
+                i in current
+                and current[i] in fsms[i].map
+                and actual_symbol in fsms[i].map[current[i]]
+            ):
                 next[i] = fsms[i].map[current[i]][actual_symbol]
         if len(next.keys()) == 0:
             raise OblivionError

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -201,13 +201,15 @@ class Fsm:
         return self.reversed().reversed()
 
     def __repr__(self, /) -> str:
-        args = ", ".join([
-            f"alphabet={self.alphabet!r}",
-            f"states={self.states!r}",
-            f"initial={self.initial!r}",
-            f"finals={self.finals!r}",
-            f"map={self.map!r}",
-        ])
+        args = ", ".join(
+            [
+                f"alphabet={self.alphabet!r}",
+                f"states={self.states!r}",
+                f"initial={self.initial!r}",
+                f"finals={self.finals!r}",
+                f"map={self.map!r}",
+            ]
+        )
         return f"Fsm({args})"
 
     def __str__(self, /) -> str:
@@ -520,12 +522,14 @@ class Fsm:
             current: frozenset[state_type],
             symbol: alpha_type,
         ) -> frozenset[state_type]:
-            next = frozenset([
-                prev
-                for prev in self.map
-                for state in current
-                if symbol in self.map[prev] and self.map[prev][symbol] == state
-            ])
+            next = frozenset(
+                [
+                    prev
+                    for prev in self.map
+                    for state in current
+                    if symbol in self.map[prev] and self.map[prev][symbol] == state
+                ]
+            )
             if len(next) == 0:
                 raise OblivionError
             return next
@@ -861,7 +865,8 @@ def parallel(
     alphabet = set().union(*[fsm.alphabet for fsm in fsms])
 
     initial: Mapping[int, state_type] = dict(
-        [(i, fsm.initial) for i, fsm in enumerate(fsms)])
+        [(i, fsm.initial) for i, fsm in enumerate(fsms)]
+    )
 
     # dedicated function accepts a "superset" and returns the next "superset"
     # obtained by following this transition in the new FSM

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -137,8 +137,7 @@ class Fsm:
         # once.
         if initial not in states:
             raise Exception(
-                f"Initial state {initial!r}"
-                f" must be one of {states!r}"
+                f"Initial state {initial!r} must be one of {states!r}"
             )
         if not finals.issubset(states):
             raise Exception(
@@ -398,8 +397,7 @@ class Fsm:
             for substate, iteration in state:
                 if substate == self.initial \
                    and (
-                       self.initial in self.finals
-                       or iteration == multiplier
+                       self.initial in self.finals or iteration == multiplier
                    ):
                     return True
             return False

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -136,14 +136,9 @@ class Fsm:
         # Validation. Thanks to immutability, this only needs to be carried out
         # once.
         if initial not in states:
-            raise Exception(
-                f"Initial state {initial!r} must be one of {states!r}"
-            )
+            raise Exception(f"Initial state {initial!r} must be one of {states!r}")
         if not finals.issubset(states):
-            raise Exception(
-                f"Final states {finals!r}"
-                f" must be a subset of {states!r}"
-            )
+            raise Exception(f"Final states {finals!r} must be a subset of {states!r}")
         for state, _state_trans in map.items():
             if state not in states:
                 raise Exception(f"Transition from unknown state {state!r}")
@@ -247,9 +242,7 @@ class Fsm:
         # column widths
         colwidths = []
         for x in range(len(rows[0])):
-            colwidths.append(max(
-                len(str(rows[y][x])) for y in range(len(rows))
-            ) + 1)
+            colwidths.append(max(len(str(rows[y][x])) for y in range(len(rows))) + 1)
 
         # apply padding
         for y in range(len(rows)):
@@ -320,10 +313,7 @@ class Fsm:
                         ANYTHING_ELSE in fsm.map[substate]
                         and symbol not in fsm.alphabet
                     ):
-                        next.update(connect_all(
-                            i,
-                            fsm.map[substate][ANYTHING_ELSE]
-                        ))
+                        next.update(connect_all(i, fsm.map[substate][ANYTHING_ELSE]))
             if len(next) == 0:
                 raise OblivionError
             return frozenset(next)
@@ -668,10 +658,7 @@ class Fsm:
         Difference. Returns an FSM which recognises only the strings
         recognised by the first FSM in the list, but none of the others.
         """
-        return parallel(
-            fsms,
-            lambda accepts: accepts[0] and not any(accepts[1:])
-        )
+        return parallel(fsms, lambda accepts: accepts[0] and not any(accepts[1:]))
 
     def __sub__(self, other: Fsm, /) -> Fsm:
         return self.difference(other)
@@ -885,10 +872,7 @@ def parallel(
         next = {}
         for i in range(len(fsms)):
             actual_symbol: alpha_type
-            if (
-                symbol not in fsms[i].alphabet
-                and ANYTHING_ELSE in fsms[i].alphabet
-            ):
+            if symbol not in fsms[i].alphabet and ANYTHING_ELSE in fsms[i].alphabet:
                 actual_symbol = ANYTHING_ELSE
             else:
                 actual_symbol = symbol
@@ -905,10 +889,7 @@ def parallel(
     # Determine the "is final?" condition of each substate, then pass it to the
     # test to determine finality of the overall FSM.
     def final(state: Mapping[int, state_type]) -> bool:
-        accepts = [
-            i in state and state[i] in fsm.finals
-            for i, fsm in enumerate(fsms)
-        ]
+        accepts = [i in state and state[i] in fsm.finals for i, fsm in enumerate(fsms)]
         return test(accepts)
 
     return crawl(alphabet, initial, final, follow).reduce()

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -22,7 +22,7 @@ def test_addbug() -> None:
         map={
             0: {ANYTHING_ELSE: 0, "a": 0, "b": 0, "c": 0},
             1: {ANYTHING_ELSE: 0, "a": 0, "b": 1, "c": 1},
-        }
+        },
     )
     assert int5A.accepts("")
 
@@ -35,7 +35,7 @@ def test_addbug() -> None:
             0: {ANYTHING_ELSE: 2, "a": 2, "b": 2, "c": 2},
             1: {ANYTHING_ELSE: 2, "a": 2, "b": 2, "c": 0},
             2: {ANYTHING_ELSE: 2, "a": 2, "b": 2, "c": 2},
-        }
+        },
     )
     assert int5B.accepts("c")
 
@@ -230,7 +230,7 @@ def test_crawl_reduction() -> None:
             3: {"0": 3, "1": 4},
             4: {"0": "oblivion", "1": "oblivion"},
             "oblivion": {"0": "oblivion", "1": "oblivion"},
-        }
+        },
     ).reduce()
     assert len(merged.states) == 2
 
@@ -242,7 +242,7 @@ def test_bug_28() -> None:
         states={0, 1},
         initial=0,
         finals={1},
-        map={0: {"a": 1}, 1: {"b": 1}}
+        map={0: {"a": 1}, 1: {"b": 1}},
     )
     assert abstar.accepts("a")
     assert not abstar.accepts("b")
@@ -268,7 +268,7 @@ def test_star_advanced() -> None:
             1: {"a": 2, "b": "oblivion"},
             2: {"a": "oblivion", "b": "oblivion"},
             "oblivion": {"a": "oblivion", "b": "oblivion"},
-        }
+        },
     ).star()
     assert starred.alphabet == frozenset(["a", "b"])
     assert starred.accepts("")
@@ -586,7 +586,7 @@ def test_dead_default() -> None:
             1: {"*": 2},
             2: {"/": 2, ANYTHING_ELSE: 2, "*": 3},
             3: {"/": 4, ANYTHING_ELSE: 2, "*": 3},
-        }
+        },
     )
     assert blockquote.accepts(["/", "*", "whatever", "*", "/"])
     assert not blockquote.accepts(["*", "*", "whatever", "*", "/"])
@@ -744,7 +744,7 @@ def test_oblivion_crawl(a: FixtureA) -> None:
             0: {"a": 1},
             1: {"b": 2},
             2: {"c": 3},
-        }
+        },
     )
     assert len((abc + abc).states) == 7
     assert len(abc.star().states) == 3
@@ -780,14 +780,14 @@ def test_bug_36() -> None:
         states={0},
         initial=0,
         finals={0},
-        map={0: {ANYTHING_ELSE: 0}}
+        map={0: {ANYTHING_ELSE: 0}},
     )
     etc2 = Fsm(
         alphabet={"s", ANYTHING_ELSE},
         states={0, 1},
         initial=0,
         finals={1},
-        map={0: {"s": 1}, 1: {"s": 1, ANYTHING_ELSE: 1}}
+        map={0: {"s": 1}, 1: {"s": 1, ANYTHING_ELSE: 1}},
     )
     both = etc1 & etc2
     assert etc1.accepts(["s"])
@@ -803,7 +803,7 @@ def test_add_anything_else() -> None:
         states={0, 1},
         initial=0,
         finals={1},
-        map={0: {ANYTHING_ELSE: 1}}
+        map={0: {ANYTHING_ELSE: 1}},
     )
 
     # [^b]
@@ -812,7 +812,7 @@ def test_add_anything_else() -> None:
         states={0, 1},
         initial=0,
         finals={1},
-        map={0: {ANYTHING_ELSE: 1}}
+        map={0: {ANYTHING_ELSE: 1}},
     )
     assert (fsm1 + fsm2).accepts("ba")
 

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -176,7 +176,7 @@ def test_optional_mul(a: FixtureA, b: FixtureB) -> None:
     unit = a + b
     # accepts "ab"
 
-    optional = (epsilon(a.alphabet) | unit)
+    optional = epsilon(a.alphabet) | unit
     # accepts "(ab)?
     assert optional.accepts([])
     assert not optional.accepts(["a"])

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -242,10 +242,7 @@ def test_bug_28() -> None:
         states={0, 1},
         initial=0,
         finals={1},
-        map={
-            0: {"a": 1},
-            1: {"b": 1}
-        }
+        map={0: {"a": 1}, 1: {"b": 1}}
     )
     assert abstar.accepts("a")
     assert not abstar.accepts("b")
@@ -426,23 +423,11 @@ def test_binary_3() -> None:
 def test_invalid_fsms() -> None:
     # initial state 1 is not a state
     with pytest.raises(Exception, match="Initial state"):
-        Fsm(
-            alphabet={},
-            states={},
-            initial=1,
-            finals=(),
-            map={}
-        )
+        Fsm(alphabet={}, states={}, initial=1, finals=(), map={})
 
     # final state 2 not a state
     with pytest.raises(Exception, match="Final states"):
-        Fsm(
-            alphabet={},
-            states={1},
-            initial=1,
-            finals={2},
-            map={}
-        )
+        Fsm(alphabet={}, states={1}, initial=1, finals={2}, map={})
 
     # invalid transition for state 1, symbol "a"
     with pytest.raises(Exception, match="Transition.+leads to.+not a state"):
@@ -490,9 +475,7 @@ def test_anything_else_acceptance() -> None:
         states={1},
         initial=1,
         finals={1},
-        map={
-            1: {"a": 1, "b": 1, "c": 1, ANYTHING_ELSE: 1}
-        },
+        map={1: {"a": 1, "b": 1, "c": 1, ANYTHING_ELSE: 1}},
     )
     assert a.accepts("d")
 
@@ -690,12 +673,7 @@ def test_new_set_methods(a: FixtureA, b: FixtureB) -> None:
     for string in four:
         assert string == ["a", "a"]
         break
-    assert [s for s in four] == [
-        ["a", "a"],
-        ["a", "b"],
-        ["b", "a"],
-        ["b", "b"]
-    ]
+    assert [s for s in four] == [["a", "a"], ["a", "b"], ["b", "a"], ["b", "b"]]
 
     # set.union() imitation
     assert Fsm.union(a, b) == a.union(b)
@@ -793,26 +771,14 @@ def test_bug_36() -> None:
         states={0},
         initial=0,
         finals={0},
-        map={
-            0: {
-                ANYTHING_ELSE: 0
-            }
-        }
+        map={0: {ANYTHING_ELSE: 0}}
     )
     etc2 = Fsm(
         alphabet={"s", ANYTHING_ELSE},
         states={0, 1},
         initial=0,
         finals={1},
-        map={
-            0: {
-                "s": 1
-            },
-            1: {
-                "s": 1,
-                ANYTHING_ELSE: 1
-            }
-        }
+        map={0: {"s": 1}, 1: {"s": 1, ANYTHING_ELSE: 1}}
     )
     both = etc1 & etc2
     assert etc1.accepts(["s"])

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -431,27 +431,11 @@ def test_invalid_fsms() -> None:
 
     # invalid transition for state 1, symbol "a"
     with pytest.raises(Exception, match="Transition.+leads to.+not a state"):
-        Fsm(
-            alphabet={"a"},
-            states={1},
-            initial=1,
-            finals=(),
-            map={
-                1: {"a": 2}
-            }
-        )
+        Fsm(alphabet={"a"}, states={1}, initial=1, finals=(), map={1: {"a": 2}})
 
     # invalid transition from unknown state
     with pytest.raises(Exception, match="Transition.+unknown state"):
-        Fsm(
-            alphabet={"a"},
-            states={1, 2},
-            initial=1,
-            finals=(),
-            map={
-                3: {"a": 2}
-            }
-        )
+        Fsm(alphabet={"a"}, states={1, 2}, initial=1, finals=(), map={3: {"a": 2}})
 
     # invalid transition table includes symbol outside of alphabet
     with pytest.raises(Exception, match="Invalid symbol"):
@@ -611,9 +595,7 @@ def test_dead_default() -> None:
     # strings.
     # reversed(blockquote)
     blockquote.reversed()
-    assert not (
-        blockquote.everythingbut().accepts(["/", "*", "whatever", "*", "/"])
-    )
+    assert not blockquote.everythingbut().accepts(["/", "*", "whatever", "*", "/"])
 
     # deliberately seek oblivion
     assert blockquote.everythingbut().accepts(["*"])
@@ -694,12 +676,7 @@ def test_new_set_methods(a: FixtureA, b: FixtureB) -> None:
     assert len(int_none) == 1
     assert [] in int_none
 
-    assert (
-        (a | b).difference(a)
-        == Fsm.difference((a | b), a)
-        == (a | b) - a
-        == b
-    )
+    assert (a | b).difference(a) == Fsm.difference((a | b), a) == (a | b) - a == b
     assert (
         (a | b).difference(a, b)
         == Fsm.difference((a | b), a, b)

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -590,15 +590,17 @@ def test_dead_default() -> None:
     )
     assert blockquote.accepts(["/", "*", "whatever", "*", "/"])
     assert not blockquote.accepts(["*", "*", "whatever", "*", "/"])
-    assert str(blockquote) \
-        == "  name final? * / ANYTHING_ELSE \n" \
-        + "--------------------------------\n" \
-        + "* 0    False    1               \n" \
-        + "  1    False  2                 \n" \
-        + "  2    False  3 2 2             \n" \
-        + "  3    False  3 4 2             \n" \
-        + "  4    True                     \n" \
+    assert (
+        str(blockquote)
+        == "  name final? * / ANYTHING_ELSE \n"
+        + "--------------------------------\n"
+        + "* 0    False    1               \n"
+        + "  1    False  2                 \n"
+        + "  2    False  3 2 2             \n"
+        + "  3    False  3 4 2             \n"
+        + "  4    True                     \n"
         + "  5    False                    \n"
+    )
     blockquote | blockquote
     blockquote & blockquote
     blockquote ^ blockquote
@@ -609,8 +611,9 @@ def test_dead_default() -> None:
     # strings.
     # reversed(blockquote)
     blockquote.reversed()
-    assert not blockquote.everythingbut() \
-        .accepts(["/", "*", "whatever", "*", "/"])
+    assert not (
+        blockquote.everythingbut().accepts(["/", "*", "whatever", "*", "/"])
+    )
 
     # deliberately seek oblivion
     assert blockquote.everythingbut().accepts(["*"])
@@ -691,12 +694,18 @@ def test_new_set_methods(a: FixtureA, b: FixtureB) -> None:
     assert len(int_none) == 1
     assert [] in int_none
 
-    assert (a | b).difference(a) \
-        == Fsm.difference((a | b), a) \
-        == (a | b) - a == b
-    assert (a | b).difference(a, b) \
-        == Fsm.difference((a | b), a, b) \
-        == (a | b) - a - b == null("ab")
+    assert (
+        (a | b).difference(a)
+        == Fsm.difference((a | b), a)
+        == (a | b) - a
+        == b
+    )
+    assert (
+        (a | b).difference(a, b)
+        == Fsm.difference((a | b), a, b)
+        == (a | b) - a - b
+        == null("ab")
+    )
     assert a.symmetric_difference(b) == Fsm.symmetric_difference(a, b) == a ^ b
     assert a.isdisjoint(b)
     assert a <= (a | b)

--- a/greenery/mult_test.py
+++ b/greenery/mult_test.py
@@ -59,19 +59,19 @@ def test_odd_bug():
 
 def test_mult_common():
     a = Charclass("a")
-    assert Mult(a, Multiplier(Bound(3), Bound(4))) \
-        .common(Mult(a, Multiplier(Bound(2), Bound(5)))) \
-        == Mult(a, Multiplier(Bound(2), Bound(3)))
-    assert Mult(a, Multiplier(Bound(2), INF)) \
-        .common(Mult(a, Multiplier(Bound(1), Bound(5)))) \
-        == Mult(a, Multiplier(Bound(1), Bound(5)))
-    assert Mult(a, Multiplier(Bound(3), INF)) \
-        .common(Mult(a, Multiplier(Bound(2), INF))) \
-        == Mult(a, Multiplier(Bound(2), INF))
+    assert Mult(a, Multiplier(Bound(3), Bound(4))).common(
+        Mult(a, Multiplier(Bound(2), Bound(5)))
+    ) == Mult(a, Multiplier(Bound(2), Bound(3)))
+    assert Mult(a, Multiplier(Bound(2), INF)).common(
+        Mult(a, Multiplier(Bound(1), Bound(5)))
+    ) == Mult(a, Multiplier(Bound(1), Bound(5)))
+    assert Mult(a, Multiplier(Bound(3), INF)).common(
+        Mult(a, Multiplier(Bound(2), INF))
+    ) == Mult(a, Multiplier(Bound(2), INF))
 
 
 def test_mult_dock():
     a = Charclass("a")
-    assert Mult(a, Multiplier(Bound(4), Bound(5))) \
-        .dock(Mult(a, Multiplier(Bound(3), Bound(3)))) \
-        == Mult(a, Multiplier(Bound(1), Bound(2)))
+    assert Mult(a, Multiplier(Bound(4), Bound(5))).dock(
+        Mult(a, Multiplier(Bound(3), Bound(3)))
+    ) == Mult(a, Multiplier(Bound(1), Bound(2)))

--- a/greenery/mult_test.py
+++ b/greenery/mult_test.py
@@ -15,10 +15,7 @@ def test_mult_equality():
     assert a == a
     assert a != Mult(Charclass("b"), ONE)
     assert a != Mult(Charclass("a"), QM)
-    assert a != Mult(
-        Charclass("a"),
-        Multiplier(Bound(1), Bound(2))
-    )
+    assert a != Mult(Charclass("a"), Multiplier(Bound(1), Bound(2)))
 
 
 def test_mult_str():

--- a/greenery/multiplier.py
+++ b/greenery/multiplier.py
@@ -41,10 +41,7 @@ class Multiplier:
         if self.min == INF:
             raise Exception(f"Minimum bound of a multiplier can't be {INF!r}")
         if self.min > self.max:
-            raise Exception(
-                "Invalid multiplier bounds:"
-                f" {self.min!r} and {self.max!r}"
-            )
+            raise Exception(f"Invalid multiplier bounds: {self.min!r} and {self.max!r}")
 
         # More useful than "min" and "max" in many situations
         # are "mandatory" and "optional".
@@ -62,9 +59,7 @@ class Multiplier:
 
     def __str__(self):
         if self.max == Bound(0):
-            raise Exception(
-                f"Can't serialise a multiplier with bound {self.max!r}"
-            )
+            raise Exception(f"Can't serialise a multiplier with bound {self.max!r}")
         if self in symbolic.keys():
             return symbolic[self]
         if self.min == self.max:
@@ -129,9 +124,7 @@ class Multiplier:
         This is not defined for all multipliers since they may not overlap.
         """
         if not self.canintersect(other):
-            raise Exception(
-                f"Can't compute intersection of {self!r} and {other!r}"
-            )
+            raise Exception(f"Can't compute intersection of {self!r} and {other!r}")
         a = max(self.min, other.min)
         b = min(self.max, other.max)
         return Multiplier(a, b)
@@ -141,10 +134,7 @@ class Multiplier:
         Union is not defined for all pairs of multipliers.
         E.g. {0,1} | {3,4} -> nope
         """
-        return not (
-            self.max + Bound(1) < other.min
-            or other.max + Bound(1) < self.min
-        )
+        return not (self.max + Bound(1) < other.min or other.max + Bound(1) < self.min)
 
     def __or__(self, other):
         """
@@ -153,9 +143,7 @@ class Multiplier:
         not defined for all multipliers since they may not intersect.
         """
         if not self.canunion(other):
-            raise Exception(
-                f"Can't compute the union of {self!r} and {other!r}"
-            )
+            raise Exception(f"Can't compute the union of {self!r} and {other!r}")
         a = min(self.min, other.min)
         b = max(self.max, other.max)
         return Multiplier(a, b)

--- a/greenery/multiplier.py
+++ b/greenery/multiplier.py
@@ -87,8 +87,10 @@ class Multiplier:
         at least one gap appears in the range. The first inaccessible
         number is (p+q)r+1. And no, multiplication is not commutative
         """
-        return other.optional == Bound(0) \
+        return (
+            other.optional == Bound(0)
             or self.optional * other.mandatory + Bound(1) >= self.mandatory
+        )
 
     def __mul__(self, other):
         """Multiply this multiplier by another"""

--- a/greenery/multiplier.py
+++ b/greenery/multiplier.py
@@ -39,9 +39,7 @@ class Multiplier:
 
     def __post_init__(self):
         if self.min == INF:
-            raise Exception(
-                f"Minimum bound of a multiplier can't be {INF!r}"
-            )
+            raise Exception(f"Minimum bound of a multiplier can't be {INF!r}")
         if self.min > self.max:
             raise Exception(
                 "Invalid multiplier bounds:"
@@ -95,9 +93,7 @@ class Multiplier:
     def __mul__(self, other):
         """Multiply this multiplier by another"""
         if not self.canmultiplyby(other):
-            raise Exception(
-                f"Can't multiply {self!r} by {other!r}"
-            )
+            raise Exception(f"Can't multiply {self!r} by {other!r}")
         return Multiplier(self.min * other.min, self.max * other.max)
 
     def __add__(self, other):

--- a/greenery/multiplier_test.py
+++ b/greenery/multiplier_test.py
@@ -48,30 +48,40 @@ def test_multiplier_common():
 
 def test_multiplier_subtraction():
     # a{3,4}, a{2,5} -> a{2,3} (with a{1,1}, a{0,2} left over)
-    assert Multiplier(Bound(3), Bound(4)) \
-        .common(Multiplier(Bound(2), Bound(5))) \
-        == Multiplier(Bound(2), Bound(3))
-    assert Multiplier(Bound(3), Bound(4)) - Multiplier(Bound(2), Bound(3)) \
+    assert Multiplier(Bound(3), Bound(4)).common(
+        Multiplier(Bound(2), Bound(5))
+    ) == Multiplier(Bound(2), Bound(3))
+    assert (
+        Multiplier(Bound(3), Bound(4)) - Multiplier(Bound(2), Bound(3))
         == ONE
-    assert Multiplier(Bound(2), Bound(5)) - Multiplier(Bound(2), Bound(3)) \
-        == Multiplier(Bound(0), Bound(2))
+    )
+    assert Multiplier(Bound(2), Bound(5)) - Multiplier(
+        Bound(2), Bound(3)
+    ) == Multiplier(Bound(0), Bound(2))
 
     # a{2,}, a{1,5} -> a{1,5} (with a{1,}, a{0,0} left over)
-    assert Multiplier(Bound(2), INF).common(Multiplier(Bound(1), Bound(5))) \
-        == Multiplier(Bound(1), Bound(5))
+    assert Multiplier(Bound(2), INF).common(
+        Multiplier(Bound(1), Bound(5))
+    ) == Multiplier(Bound(1), Bound(5))
     assert Multiplier(Bound(2), INF) - Multiplier(Bound(1), Bound(5)) == PLUS
-    assert Multiplier(Bound(1), Bound(5)) - Multiplier(Bound(1), Bound(5)) \
+    assert (
+        Multiplier(Bound(1), Bound(5)) - Multiplier(Bound(1), Bound(5))
         == ZERO
+    )
 
     # a{3,}, a{2,} -> a{2,} (with a, epsilon left over)
-    assert Multiplier(Bound(3), INF).common(Multiplier(Bound(2), INF)) \
+    assert (
+        Multiplier(Bound(3), INF).common(Multiplier(Bound(2), INF))
         == Multiplier(Bound(2), INF)
+    )
     assert Multiplier(Bound(3), INF) - Multiplier(Bound(2), INF) == ONE
     assert Multiplier(Bound(2), INF) - Multiplier(Bound(2), INF) == ZERO
 
     # a{3,}, a{3,} -> a{3,} (with ZERO, ZERO left over)
-    assert Multiplier(Bound(3), INF).common(Multiplier(Bound(3), INF)) \
+    assert (
+        Multiplier(Bound(3), INF).common(Multiplier(Bound(3), INF))
         == Multiplier(Bound(3), INF)
+    )
     assert Multiplier(Bound(3), INF) - Multiplier(Bound(3), INF) == ZERO
 
 

--- a/greenery/multiplier_test.py
+++ b/greenery/multiplier_test.py
@@ -59,8 +59,7 @@ def test_multiplier_subtraction():
     # a{2,}, a{1,5} -> a{1,5} (with a{1,}, a{0,0} left over)
     assert Multiplier(Bound(2), INF).common(Multiplier(Bound(1), Bound(5))) \
         == Multiplier(Bound(1), Bound(5))
-    assert Multiplier(Bound(2), INF) - Multiplier(Bound(1), Bound(5)) \
-        == PLUS
+    assert Multiplier(Bound(2), INF) - Multiplier(Bound(1), Bound(5)) == PLUS
     assert Multiplier(Bound(1), Bound(5)) - Multiplier(Bound(1), Bound(5)) \
         == ZERO
 

--- a/greenery/multiplier_test.py
+++ b/greenery/multiplier_test.py
@@ -51,10 +51,7 @@ def test_multiplier_subtraction():
     assert Multiplier(Bound(3), Bound(4)).common(
         Multiplier(Bound(2), Bound(5))
     ) == Multiplier(Bound(2), Bound(3))
-    assert (
-        Multiplier(Bound(3), Bound(4)) - Multiplier(Bound(2), Bound(3))
-        == ONE
-    )
+    assert Multiplier(Bound(3), Bound(4)) - Multiplier(Bound(2), Bound(3)) == ONE
     assert Multiplier(Bound(2), Bound(5)) - Multiplier(
         Bound(2), Bound(3)
     ) == Multiplier(Bound(0), Bound(2))
@@ -64,23 +61,18 @@ def test_multiplier_subtraction():
         Multiplier(Bound(1), Bound(5))
     ) == Multiplier(Bound(1), Bound(5))
     assert Multiplier(Bound(2), INF) - Multiplier(Bound(1), Bound(5)) == PLUS
-    assert (
-        Multiplier(Bound(1), Bound(5)) - Multiplier(Bound(1), Bound(5))
-        == ZERO
-    )
+    assert Multiplier(Bound(1), Bound(5)) - Multiplier(Bound(1), Bound(5)) == ZERO
 
     # a{3,}, a{2,} -> a{2,} (with a, epsilon left over)
-    assert (
-        Multiplier(Bound(3), INF).common(Multiplier(Bound(2), INF))
-        == Multiplier(Bound(2), INF)
+    assert Multiplier(Bound(3), INF).common(Multiplier(Bound(2), INF)) == Multiplier(
+        Bound(2), INF
     )
     assert Multiplier(Bound(3), INF) - Multiplier(Bound(2), INF) == ONE
     assert Multiplier(Bound(2), INF) - Multiplier(Bound(2), INF) == ZERO
 
     # a{3,}, a{3,} -> a{3,} (with ZERO, ZERO left over)
-    assert (
-        Multiplier(Bound(3), INF).common(Multiplier(Bound(3), INF))
-        == Multiplier(Bound(3), INF)
+    assert Multiplier(Bound(3), INF).common(Multiplier(Bound(3), INF)) == Multiplier(
+        Bound(3), INF
     )
     assert Multiplier(Bound(3), INF) - Multiplier(Bound(3), INF) == ZERO
 
@@ -113,15 +105,7 @@ def test_multiplier_union():
     assert PLUS | PLUS == PLUS
     assert not ZERO.canunion(Multiplier(Bound(2), INF))
     assert not ONE.canunion(Multiplier(Bound(3), Bound(4)))
-    assert not Multiplier(
-        Bound(8),
-        INF
-    ).canunion(
-        Multiplier(
-            Bound(3),
-            Bound(4)
-        )
-    )
+    assert not Multiplier(Bound(8), INF).canunion(Multiplier(Bound(3), Bound(4)))
 
     with pytest.raises(Exception, match="Can't compute the union"):
         ZERO | Multiplier(Bound(7), Bound(8))

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -135,7 +135,7 @@ def match_class_interior_1(string, i):
         pass
 
     # Attempt 3: just a character on its own
-    (char, j) = match_internal_char(string, i)
+    char, j = match_internal_char(string, i)
     return frozenset(char), False, j
 
 

--- a/greenery/parse_test.py
+++ b/greenery/parse_test.py
@@ -72,15 +72,15 @@ def test_mult_matching():
     assert match_mult("abcde[^fg]*", 5) == (Mult(~Charclass("fg"), STAR), 11)
     assert match_mult("abcde[^fg]*h{5}[a-z]+", 11) == (
         Mult(Charclass("h"), Multiplier(Bound(5), Bound(5))),
-        15
+        15,
     )
     assert match_mult("abcde[^fg]*h{5}[a-z]+T{1,}", 15) == (
         Mult(Charclass("abcdefghijklmnopqrstuvwxyz"), PLUS),
-        21
+        21,
     )
     assert match_mult("abcde[^fg]*h{5}[a-z]+T{2,}", 21) == (
         Mult(Charclass("T"), Multiplier(Bound(2), INF)),
-        26
+        26,
     )
 
 

--- a/greenery/parse_test.py
+++ b/greenery/parse_test.py
@@ -14,9 +14,7 @@ from .rxelems import Conc, Mult, Pattern
 # mypy: allow-untyped-defs
 
 if __name__ == "__main__":
-    raise Exception(
-        "Test files can't be run directly. Use `python -m pytest greenery`"
-    )
+    raise Exception("Test files can't be run directly. Use `python -m pytest greenery`")
 
 
 def test_charclass_matching():

--- a/greenery/parse_test.py
+++ b/greenery/parse_test.py
@@ -69,10 +69,7 @@ def test_negated_negatives_inside_charclasses():
 
 
 def test_mult_matching():
-    assert match_mult("abcde[^fg]*", 5) == (
-        Mult(~Charclass("fg"), STAR),
-        11
-    )
+    assert match_mult("abcde[^fg]*", 5) == (Mult(~Charclass("fg"), STAR), 11)
     assert match_mult("abcde[^fg]*h{5}[a-z]+", 11) == (
         Mult(Charclass("h"), Multiplier(Bound(5), Bound(5))),
         15
@@ -111,29 +108,12 @@ def test_w_d_s():
 
 
 def test_mult_parsing():
-    assert parse("[a-g]+") == Pattern(
-        Conc(
-            Mult(
-                Charclass("abcdefg"),
-                PLUS
-            )
-        )
-    )
+    assert parse("[a-g]+") == Pattern(Conc(Mult(Charclass("abcdefg"), PLUS)))
     assert parse("[a-g0-8$%]+") == Pattern(
-        Conc(
-            Mult(
-                Charclass("abcdefg012345678$%"),
-                PLUS
-            )
-        )
+        Conc(Mult(Charclass("abcdefg012345678$%"), PLUS))
     )
     assert parse("[a-g0-8$%\\^]+") == Pattern(
-        Conc(
-            Mult(
-                Charclass("abcdefg012345678$%^"),
-                PLUS
-            )
-        )
+        Conc(Mult(Charclass("abcdefg012345678$%^"), PLUS))
     )
 
 

--- a/greenery/pattern_test.py
+++ b/greenery/pattern_test.py
@@ -76,9 +76,7 @@ def test_mult_reduction_easy():
                 ZERO,
             )
         )
-    ).reduce() == Pattern(
-        Conc()
-    )
+    ).reduce() == Pattern(Conc())
     assert str(
         Pattern(
             Conc(

--- a/greenery/pattern_test.py
+++ b/greenery/pattern_test.py
@@ -26,41 +26,56 @@ def test_pattern_equality():
 
 
 def test_pattern_str():
-    assert str(Pattern(
-        Conc(Mult(Charclass("a"), ONE)),
-        Conc(Mult(Charclass("b"), ONE)),
-    )) == "a|b"
-    assert str(Pattern(
-        Conc(Mult(Charclass("a"), ONE)),
-        Conc(Mult(Charclass("a"), ONE)),
-    )) == "a"
-    assert str(Pattern(
-        Conc(
-            Mult(Charclass("a"), ONE),
-            Mult(Charclass("b"), ONE),
-            Mult(Charclass("c"), ONE),
-        ),
-        Conc(
-            Mult(Charclass("d"), ONE),
-            Mult(Charclass("e"), ONE),
-            Mult(Charclass("f"), ONE),
-            Mult(
-                Pattern(
-                    Conc(
-                        Mult(Charclass("g"), ONE),
-                        Mult(Charclass("h"), ONE),
-                        Mult(Charclass("i"), ONE),
-                    ),
-                    Conc(
-                        Mult(Charclass("j"), ONE),
-                        Mult(Charclass("k"), ONE),
-                        Mult(Charclass("l"), ONE),
+    assert (
+        str(
+            Pattern(
+                Conc(Mult(Charclass("a"), ONE)),
+                Conc(Mult(Charclass("b"), ONE)),
+            )
+        )
+        == "a|b"
+    )
+    assert (
+        str(
+            Pattern(
+                Conc(Mult(Charclass("a"), ONE)),
+                Conc(Mult(Charclass("a"), ONE)),
+            )
+        )
+        == "a"
+    )
+    assert (
+        str(
+            Pattern(
+                Conc(
+                    Mult(Charclass("a"), ONE),
+                    Mult(Charclass("b"), ONE),
+                    Mult(Charclass("c"), ONE),
+                ),
+                Conc(
+                    Mult(Charclass("d"), ONE),
+                    Mult(Charclass("e"), ONE),
+                    Mult(Charclass("f"), ONE),
+                    Mult(
+                        Pattern(
+                            Conc(
+                                Mult(Charclass("g"), ONE),
+                                Mult(Charclass("h"), ONE),
+                                Mult(Charclass("i"), ONE),
+                            ),
+                            Conc(
+                                Mult(Charclass("j"), ONE),
+                                Mult(Charclass("k"), ONE),
+                                Mult(Charclass("l"), ONE),
+                            ),
+                        ),
+                        ONE,
                     ),
                 ),
-                ONE,
-            ),
-        ),
-    )) == "abc|def(ghi|jkl)"
+            )
+        )
+        == "abc|def(ghi|jkl)"
+    )
 
 
 def test_empty():
@@ -77,16 +92,19 @@ def test_mult_reduction_easy():
             )
         )
     ).reduce() == Pattern(Conc())
-    assert str(
-        Pattern(
-            Conc(
-                Mult(
-                    Charclass("a"),
-                    ZERO,
+    assert (
+        str(
+            Pattern(
+                Conc(
+                    Mult(
+                        Charclass("a"),
+                        ZERO,
+                    )
                 )
-            )
-        ).reduce()
-    ) == ""
+            ).reduce()
+        )
+        == ""
+    )
 
 
 def test_empty_pattern_reduction():
@@ -94,14 +112,19 @@ def test_empty_pattern_reduction():
 
 
 def test_empty_conc_suppression():
-    assert str(Pattern(
-        Conc(
-            # this `Mult` can never actually match anything
-            Mult(Pattern(), ONE),
-            Mult(Charclass("0"), ONE),
-            Mult(Charclass("0123456789"), ONE),
-        )  # so neither can this `Conc`
-    ).reduce()) == "[]"
+    assert (
+        str(
+            Pattern(
+                Conc(
+                    # this `Mult` can never actually match anything
+                    Mult(Pattern(), ONE),
+                    Mult(Charclass("0"), ONE),
+                    Mult(Charclass("0123456789"), ONE),
+                )  # so neither can this `Conc`
+            ).reduce()
+        )
+        == "[]"
+    )
 
 
 def test_pattern_dock():

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -122,7 +122,7 @@ class Conc:
                     if rm_sm_intersection.equivalent(rm_pattern):
                         trimmed = Mult(
                             rm_pattern,
-                            Multiplier(r.multiplier.min, r.multiplier.min)
+                            Multiplier(r.multiplier.min, r.multiplier.min),
                         )
                         new = self.mults[:i] + (trimmed, s) + self.mults[i + 2:]
                         return Conc(*new).reduce()
@@ -140,7 +140,7 @@ class Conc:
                     if rm_sm_intersection.equivalent(sm_pattern):
                         trimmed = Mult(
                             sm_pattern,
-                            Multiplier(s.multiplier.min, s.multiplier.min)
+                            Multiplier(s.multiplier.min, s.multiplier.min),
                         )
                         new = self.mults[:i] + (r, trimmed) + self.mults[i + 2:]
                         return Conc(*new).reduce()
@@ -890,7 +890,7 @@ class Mult:
             ):
                 return Mult(
                     conc.mults[0].multiplicand,
-                    conc.mults[0].multiplier * self.multiplier
+                    conc.mults[0].multiplier * self.multiplier,
                 ).reduce()
 
         # no reduction possible

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -27,7 +27,7 @@ from .multiplier import ONE, QM, STAR, ZERO, Multiplier
 
 
 @dataclass(frozen=True)
-class Conc():
+class Conc:
     """
     A `Conc` (short for "concatenation") is a tuple of `Mult`s i.e. an
     unbroken string of mults occurring one after the other.
@@ -68,10 +68,7 @@ class Conc():
                 # Conc contains "()" (i.e. a `Mult` containing only a `Pattern`
                 # containing the empty string)? That can be removed
                 # e.g. "a()b" -> "ab"
-
-                (
-                    mult.multiplicand == Pattern(EMPTYSTRING)
-                ) \
+                mult.multiplicand == Pattern(EMPTYSTRING) \
 
                 # If a `Mult` has an empty multiplicand, we can only match it
                 # zero times => empty string => remove it entirely

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -79,7 +79,7 @@ class Conc:
                 # e.g. "a[XYZ]{0}b" -> "ab"
                 or mult.multiplier == ZERO
             ):
-                new = self.mults[:i] + self.mults[i + 1:]
+                new = self.mults[:i] + self.mults[i + 1 :]
                 return Conc(*new).reduce()
 
         # We might be able to combine some mults together or at least simplify
@@ -103,7 +103,7 @@ class Conc:
                 # e.g. ab?b?c -> ab{0,2}c
                 if rm_pattern == sm_pattern:
                     squished = Mult(rm_pattern, r.multiplier + s.multiplier)
-                    new = self.mults[:i] + (squished,) + self.mults[i + 2:]
+                    new = self.mults[:i] + (squished,) + self.mults[i + 2 :]
                     return Conc(*new).reduce()
 
                 # If R's language is a subset of S's, then R{a,b}S{c,} reduces
@@ -117,7 +117,7 @@ class Conc:
                             rm_pattern,
                             Multiplier(r.multiplier.min, r.multiplier.min),
                         )
-                        new = self.mults[:i] + (trimmed, s) + self.mults[i + 2:]
+                        new = self.mults[:i] + (trimmed, s) + self.mults[i + 2 :]
                         return Conc(*new).reduce()
 
                 # Conversely, if R is superset of S, then R{c,}S{a,b} reduces
@@ -132,7 +132,7 @@ class Conc:
                             sm_pattern,
                             Multiplier(s.multiplier.min, s.multiplier.min),
                         )
-                        new = self.mults[:i] + (r, trimmed) + self.mults[i + 2:]
+                        new = self.mults[:i] + (r, trimmed) + self.mults[i + 2 :]
                         return Conc(*new).reduce()
 
         # Conc contains (among other things) a *singleton* `Mult` containing
@@ -147,7 +147,7 @@ class Conc:
                 and len(mult.multiplicand.concs) == 1
             ):
                 (conc,) = mult.multiplicand.concs
-                new = self.mults[:i] + conc.mults + self.mults[i + 1:]
+                new = self.mults[:i] + conc.mults + self.mults[i + 1 :]
                 return Conc(*new).reduce()
 
         return self
@@ -513,8 +513,8 @@ class Pattern:
                 multiplier = multiplier1 | multiplier2
                 newconcs = (
                     oldconcs[:i]
-                    + oldconcs[i + 1:j]
-                    + oldconcs[j + 1:]
+                    + oldconcs[i + 1 : j]
+                    + oldconcs[j + 1 :]
                     + [Conc(Mult(multiplicand, multiplier))]
                 )
                 return Pattern(*newconcs).reduce()

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -68,8 +68,7 @@ class Conc:
                 # Conc contains "()" (i.e. a `Mult` containing only a `Pattern`
                 # containing the empty string)? That can be removed
                 # e.g. "a()b" -> "ab"
-                mult.multiplicand == Pattern(EMPTYSTRING) \
-
+                mult.multiplicand == Pattern(EMPTYSTRING)
                 # If a `Mult` has an empty multiplicand, we can only match it
                 # zero times => empty string => remove it entirely
                 # e.g. "a[]{0,3}b" -> "ab"
@@ -77,8 +76,7 @@ class Conc:
                 or (
                     mult.multiplicand.empty()
                     and mult.multiplier.min == Bound(0)
-                ) \
-
+                )
                 # Failing that, we have a positive multiplicand which we
                 # intend to match zero times. In this case the only possible
                 # match is the empty string => remove it
@@ -116,8 +114,10 @@ class Conc:
                 # to R{a}S{c,}...
                 # e.g. \d+\w+ -> \d\w+
                 # Do the cheapest checks first
-                if r.multiplier.min < r.multiplier.max \
-                   and s.multiplier.max == INF:
+                if (
+                    r.multiplier.min < r.multiplier.max
+                    and s.multiplier.max == INF
+                ):
                     rm_sm_intersection = rm_pattern & sm_pattern
                     if rm_sm_intersection.equivalent(rm_pattern):
                         trimmed = Mult(
@@ -131,8 +131,10 @@ class Conc:
                 # to R{c,}S{a}.
                 # e.g. [ab]+a? -> [ab]+
                 # Do the cheapest checks first
-                if r.multiplier.max == INF \
-                   and s.multiplier.min < s.multiplier.max:
+                if (
+                    r.multiplier.max == INF
+                    and s.multiplier.min < s.multiplier.max
+                ):
                     if rm_sm_intersection is None:
                         rm_sm_intersection = rm_pattern & sm_pattern
                     if rm_sm_intersection.equivalent(sm_pattern):
@@ -149,9 +151,11 @@ class Conc:
         # BUT NOT "a(d(ab|a*c)){2,}"
         # AND NOT "a(d(ab|a*c)|y)"
         for i, mult in enumerate(self.mults):
-            if mult.multiplier == ONE \
-               and isinstance(mult.multiplicand, Pattern) \
-               and len(mult.multiplicand.concs) == 1:
+            if (
+                mult.multiplier == ONE
+                and isinstance(mult.multiplicand, Pattern)
+                and len(mult.multiplicand.concs) == 1
+            ):
                 (conc,) = mult.multiplicand.concs
                 new = self.mults[:i] + conc.mults + self.mults[i + 1:]
                 return Conc(*new).reduce()
@@ -497,9 +501,11 @@ class Pattern:
         # 1, and the multiplicand is a `Pattern`, pull that up
         if len(self.concs) == 1:
             (conc,) = self.concs
-            if len(conc.mults) == 1 \
-               and conc.mults[0].multiplier == ONE \
-               and isinstance(conc.mults[0].multiplicand, Pattern):
+            if (
+                len(conc.mults) == 1
+                and conc.mults[0].multiplier == ONE
+                and isinstance(conc.mults[0].multiplicand, Pattern)
+            ):
                 return conc.mults[0].multiplicand.reduce()
 
         # If this `Pattern` contains several `Conc`s each containing just 1
@@ -525,11 +531,12 @@ class Pattern:
                 if not multiplier1.canunion(multiplier2):
                     continue
                 multiplier = multiplier1 | multiplier2
-                newconcs = \
-                    oldconcs[:i] \
-                    + oldconcs[i + 1:j] \
-                    + oldconcs[j + 1:] \
+                newconcs = (
+                    oldconcs[:i]
+                    + oldconcs[i + 1:j]
+                    + oldconcs[j + 1:]
                     + [Conc(Mult(multiplicand, multiplier))]
+                )
                 return Pattern(*newconcs).reduce()
 
         # If this `Pattern` contains several `Conc`s each containing just 1
@@ -540,9 +547,11 @@ class Pattern:
         num_merged = 0
         rest = []
         for conc in self.concs:
-            if len(conc.mults) == 1 \
-               and conc.mults[0].multiplier == ONE \
-               and isinstance(conc.mults[0].multiplicand, Charclass):
+            if (
+                len(conc.mults) == 1
+                and conc.mults[0].multiplier == ONE
+                and isinstance(conc.mults[0].multiplicand, Charclass)
+            ):
                 merged_charclass |= conc.mults[0].multiplicand
                 num_merged += 1
             else:
@@ -556,8 +565,10 @@ class Pattern:
             for conc in self.concs:
                 # ...and there is another `Conc`
                 # with a single `Mult` whose lower bound is 0...
-                if len(conc.mults) == 1 \
-                   and conc.mults[0].multiplier.min == Bound(0):
+                if (
+                    len(conc.mults) == 1
+                    and conc.mults[0].multiplier.min == Bound(0)
+                ):
                     # Then we can omit the empty string.
                     # E.g. "|(ab)*|def" => "(ab)*|def".
                     return Pattern(*(self.concs - {EMPTYSTRING})).reduce()
@@ -565,8 +576,10 @@ class Pattern:
             for conc in self.concs:
                 # ...and there is another `Conc`
                 # with a single `Mult` whose lower bound is 1...
-                if len(conc.mults) == 1 \
-                   and conc.mults[0].multiplier.min == Bound(1):
+                if (
+                    len(conc.mults) == 1
+                    and conc.mults[0].multiplier.min == Bound(1)
+                ):
                     # Then we can merge the empty string into that.
                     # E.g. "|(ab)+|def" => "(ab)*|def".
                     merged_conc = Conc(
@@ -782,9 +795,11 @@ class Mult:
     multiplier: Multiplier
 
     def __eq__(self, other):
-        return isinstance(other.multiplicand, type(self.multiplicand)) \
-            and self.multiplicand == other.multiplicand \
+        return (
+            isinstance(other.multiplicand, type(self.multiplicand))
+            and self.multiplicand == other.multiplicand
             and self.multiplier == other.multiplier
+        )
 
     def __hash__(self):
         return hash((self.multiplicand, self.multiplier))
@@ -843,9 +858,11 @@ class Mult:
         # instead.
         # e.g. (A|B|C|) -> (A|B|C)?
         # e.g. (A|B|C|){2} -> (A|B|C){0,2}
-        if isinstance(self.multiplicand, Pattern) \
-           and EMPTYSTRING in self.multiplicand.concs \
-           and self.multiplier.canmultiplyby(QM):
+        if (
+            isinstance(self.multiplicand, Pattern)
+            and EMPTYSTRING in self.multiplicand.concs
+            and self.multiplier.canmultiplyby(QM)
+        ):
             return Mult(
                 Pattern(
                     *filter(
@@ -863,11 +880,14 @@ class Mult:
         # e.g. ((a))* -> (a)* -> a*
         # NOTE: this logic lives here at the `Mult` level, NOT in
         # `Pattern.reduce` because we want to return another `Mult` (same type)
-        if isinstance(self.multiplicand, Pattern) \
-           and len(self.multiplicand.concs) == 1:
+        if (
+            isinstance(self.multiplicand, Pattern)
+            and len(self.multiplicand.concs) == 1
+        ):
             (conc,) = self.multiplicand.concs
-            if len(conc.mults) == 1 \
-               and conc.mults[0].multiplier.canmultiplyby(self.multiplier):
+            if len(conc.mults) == 1 and conc.mults[0].multiplier.canmultiplyby(
+                self.multiplier
+            ):
                 return Mult(
                     conc.mults[0].multiplicand,
                     conc.mults[0].multiplier * self.multiplier

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -108,10 +108,7 @@ class Conc:
                 # If R = S, then we can squish the multipliers together
                 # e.g. ab?b?c -> ab{0,2}c
                 if rm_pattern == sm_pattern:
-                    squished = Mult(
-                        rm_pattern,
-                        r.multiplier + s.multiplier
-                    )
+                    squished = Mult(rm_pattern, r.multiplier + s.multiplier)
                     new = self.mults[:i] + (squished,) + self.mults[i + 2:]
                     return Conc(*new).reduce()
 
@@ -127,9 +124,7 @@ class Conc:
                             rm_pattern,
                             Multiplier(r.multiplier.min, r.multiplier.min)
                         )
-                        new = self.mults[:i] \
-                            + (trimmed, s) \
-                            + self.mults[i + 2:]
+                        new = self.mults[:i] + (trimmed, s) + self.mults[i + 2:]
                         return Conc(*new).reduce()
 
                 # Conversely, if R is superset of S, then R{c,}S{a,b} reduces
@@ -145,9 +140,7 @@ class Conc:
                             sm_pattern,
                             Multiplier(s.multiplier.min, s.multiplier.min)
                         )
-                        new = self.mults[:i] \
-                            + (r, trimmed) \
-                            + self.mults[i + 2:]
+                        new = self.mults[:i] + (r, trimmed) + self.mults[i + 2:]
                         return Conc(*new).reduce()
 
         # Conc contains (among other things) a *singleton* `Mult` containing
@@ -256,9 +249,7 @@ class Conc:
             # then tries to subtract the B too, which isn't possible
             else:
                 if i != 0:
-                    raise Exception(
-                        f"Can't subtract {other!r} from {self!r}"
-                    )
+                    raise Exception(f"Can't subtract {other!r} from {self!r}")
 
         return Conc(*new)
 
@@ -389,10 +380,7 @@ def from_fsm(f: Fsm) -> Pattern:
             for right in brz[a]:
                 brz[b][right] = Pattern(
                     *brz[b][right].concs,
-                    Conc(
-                        Mult(univ, ONE),
-                        Mult(brz[a][right], ONE)
-                    )
+                    Conc(Mult(univ, ONE), Mult(brz[a][right], ONE)),
                 ).reduce()
 
     return brz[f.initial][outside].reduce()
@@ -657,10 +645,7 @@ class Pattern:
         if len(self.concs) == 0:
             raise Exception(f"Can't call _commonconc on {self!r}")
 
-        return reduce(
-            lambda x, y: x.common(y, suffix=suffix),
-            self.concs
-        )
+        return reduce(lambda x, y: x.common(y, suffix=suffix), self.concs)
 
     def to_fsm(self, alphabet=None):
         if alphabet is None:
@@ -815,9 +800,7 @@ class Mult:
         e.g. a{4,5} - a{3} = a{1,2}
         """
         if other.multiplicand != self.multiplicand:
-            raise Exception(
-                f"Can't subtract {other!r} from {self!r}"
-            )
+            raise Exception(f"Can't subtract {other!r} from {self!r}")
         return Mult(self.multiplicand, self.multiplier - other.multiplier)
 
     def common(self, other):

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -730,7 +730,6 @@ class Pattern:
         # single example. You must supply your own "otherchar" to stand in for
         # all of these possibilities.
         for string in self.to_fsm().strings():
-
             # Have to represent `ANYTHING_ELSE` somehow.
             if ANYTHING_ELSE in string:
                 if otherchar is None:

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -258,8 +258,7 @@ def test_wildcard_generator():
 
 
 def test_forin():
-    assert [s for s in parse("abc|def(ghi|jkl)")] \
-        == ["abc", "defghi", "defjkl"]
+    assert [s for s in parse("abc|def(ghi|jkl)")] == ["abc", "defghi", "defjkl"]
 
 
 ###############################################################################
@@ -468,9 +467,7 @@ def test_bad_alphabet():
             states={0},
             initial=0,
             finals=(),
-            map={
-                0: {bad_symbol: 0}
-            },
+            map={0: {bad_symbol: 0}},
         )
 
         with pytest.raises(Exception, match="Symbol.*cannot be used"):
@@ -552,9 +549,7 @@ def test_isinstance_bug():
     # Problem relating to isinstance(). The class `Mult` was occurring as both
     # rxelems.Mult and as __main__.Mult and apparently these count as different
     # classes for some reason, so isinstance(m, Mult) was returning false.
-    var = str(parse("").everythingbut()) \
-        + "aa" \
-        + str(parse("").everythingbut())
+    var = str(parse("").everythingbut()) + "aa" + str(parse("").everythingbut())
     assert var == ".+aa.+"
 
     starfree = parse(var).everythingbut()
@@ -650,16 +645,11 @@ def test_reduce_concatenations():
 
 
 def test_mult_multiplication():
-    assert parse("(a{2,3}){1,1}").reduce() \
-        == parse("a{2,3}").reduce()
-    assert parse("(a{2,3}){1}").reduce() \
-        == parse("a{2,3}").reduce()
-    assert parse("(a{2,3})").reduce() \
-        == parse("a{2,3}").reduce()
-    assert parse("(a{2,3}){4,5}").reduce() \
-        == parse("a{8,15}").reduce()
-    assert parse("(a{2,}){2,}").reduce() \
-        == parse("a{4,}").reduce()
+    assert parse("(a{2,3}){1,1}").reduce() == parse("a{2,3}").reduce()
+    assert parse("(a{2,3}){1}").reduce() == parse("a{2,3}").reduce()
+    assert parse("(a{2,3})").reduce() == parse("a{2,3}").reduce()
+    assert parse("(a{2,3}){4,5}").reduce() == parse("a{8,15}").reduce()
+    assert parse("(a{2,}){2,}").reduce() == parse("a{4,}").reduce()
 
 
 def test_even_star_bug2():
@@ -711,23 +701,17 @@ def test_parse_regex_intersection():
     assert parse("[ab]{0,2}").matches("")
     assert parse("[^a]{0,2}").matches("")
     assert parse("b{0,2}").matches("")
-    assert str(parse("[ab]{0,2}") & parse("[^a]{0,2}")) \
-        == "b{0,2}"
-    assert str(parse("[ab]{0,4}") & parse("[^a]{0,4}")) \
-        == "b{0,4}"
-    assert str(parse("[abc]{0,8}") & parse("[^a]{0,8}")) \
-        == "[bc]{0,8}"
+    assert str(parse("[ab]{0,2}") & parse("[^a]{0,2}")) == "b{0,2}"
+    assert str(parse("[ab]{0,4}") & parse("[^a]{0,4}")) == "b{0,4}"
+    assert str(parse("[abc]{0,8}") & parse("[^a]{0,8}")) == "[bc]{0,8}"
     assert str(parse("[a-g0-8$%\\^]{0,8}") & parse("[^d]{0,8}")) \
         == "[$%0-8\\^abcefg]{0,8}"
     assert str(parse("[a-g0-8$%\\^]+") & parse("[^d]{0,8}")) \
         == "[$%0-8\\^abcefg]{1,8}"
     assert str(parse("[a-g0-8$%\\^]+") & parse("[^d]{2,8}")) \
         == "[$%0-8\\^abcefg]{2,8}"
-    assert str(
-        parse("\\W*")
-        & parse("[a-g0-8$%\\^]+")
-        & parse("[^d]{2,8}")
-    ) == "[$%\\^]{2,8}"
+    assert str(parse("\\W*") & parse("[a-g0-8$%\\^]+") & parse("[^d]{2,8}")) \
+        == "[$%\\^]{2,8}"
     assert str(parse("\\d{4}-\\d{2}-\\d{2}") & parse("19.*")) \
         == "19\\d{2}-\\d{2}-\\d{2}"
 
@@ -835,8 +819,7 @@ def test_mult_squoosh():
     # sequence squooshing of mults within a `Conc`
     assert str(parse("[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]").reduce()) \
         == "[0-9A-Fa-f]{3}"
-    assert str(parse("[$%\\^]?[$%\\^]").reduce()) \
-        == "[$%\\^]{1,2}"
+    assert str(parse("[$%\\^]?[$%\\^]").reduce()) == "[$%\\^]{1,2}"
     assert str(parse(
         "(|(|(|(|(|[$%\\^])[$%\\^])[$%\\^])[$%\\^])[$%\\^])[$%\\^][$%\\^]"
     ).reduce()) \
@@ -845,14 +828,10 @@ def test_mult_squoosh():
 
 def test_bad_reduction_bug():
     # DEFECT: "0{2}|1{2}" was erroneously reduced() to "[01]{2}"
-    assert parse("0{2}|1{2}").reduce() \
-        != parse("[01]{2}")
-    assert parse("0|[1-9]|ab").reduce() \
-        == parse("\\d|ab")
-    assert parse("0|[1-9]|a{5,7}").reduce() \
-        == parse("\\d|a{5,7}")
-    assert parse("0|(0|[1-9]|a{5,7})").reduce() \
-        == parse("0|(\\d|a{5,7})")
+    assert parse("0{2}|1{2}").reduce() != parse("[01]{2}")
+    assert parse("0|[1-9]|ab").reduce() == parse("\\d|ab")
+    assert parse("0|[1-9]|a{5,7}").reduce() == parse("\\d|a{5,7}")
+    assert parse("0|(0|[1-9]|a{5,7})").reduce() == parse("0|(\\d|a{5,7})")
     # TODO: should do better than this! Merge that 0
 
 
@@ -864,10 +843,7 @@ def test_epsilon_reduction():
     assert str(parse("|(ab)*|def").reduce()) == "(ab)*|def"
     assert str(parse("|(ab)+|def").reduce()) == "(ab)*|def"
     assert str(parse("|.+").reduce()) == ".*"
-    assert str(parse("|a+|b+").reduce()) in {
-        "a+|b*",
-        "a*|b+"
-    }
+    assert str(parse("|a+|b+").reduce()) in {"a+|b*", "a*|b+"}
 
 
 def test_charclass_intersection_2():
@@ -891,26 +867,16 @@ def test_new_reduce():
 
 
 def test_main_bug():
-    assert str(parse("a*").reduce()) \
-        == "a*"
-    assert str(parse("a|a*").reduce()) \
-        == "a*"
-    assert str(parse("a{1,2}|a{3,4}|bc").reduce()) \
-        == "a{1,4}|bc"
-    assert str(parse("a{1,2}|bc|a{3,4}").reduce()) \
-        == "a{1,4}|bc"
-    assert str(parse("a{1,2}|a{3,4}|a{5,6}|bc").reduce()) \
-        == "a{1,6}|bc"
-    assert str(parse("a{1,2}|a{3}|a{5,6}").reduce()) \
-        == "a{1,2}(a?|a{4})"
-    assert str(parse("a{1,2}|a{3}|a{5,6}|bc").reduce()) \
-        == "a{1,3}|a{5,6}|bc"
-    assert str(parse("a{1,2}|a{4}|a{5,6}").reduce()) \
-        == "a{1,2}(a{3,4})?"
-    assert str(parse("a{1,2}|a{4}|a{5,6}|bc").reduce()) \
-        == "a{1,2}|a{4,6}|bc"
-    assert str((parse("a") | parse("a*")).reduce()) \
-        == "a*"
+    assert str(parse("a*").reduce()) == "a*"
+    assert str(parse("a|a*").reduce()) == "a*"
+    assert str(parse("a{1,2}|a{3,4}|bc").reduce()) == "a{1,4}|bc"
+    assert str(parse("a{1,2}|bc|a{3,4}").reduce()) == "a{1,4}|bc"
+    assert str(parse("a{1,2}|a{3,4}|a{5,6}|bc").reduce()) == "a{1,6}|bc"
+    assert str(parse("a{1,2}|a{3}|a{5,6}").reduce()) == "a{1,2}(a?|a{4})"
+    assert str(parse("a{1,2}|a{3}|a{5,6}|bc").reduce()) == "a{1,3}|a{5,6}|bc"
+    assert str(parse("a{1,2}|a{4}|a{5,6}").reduce()) == "a{1,2}(a{3,4})?"
+    assert str(parse("a{1,2}|a{4}|a{5,6}|bc").reduce()) == "a{1,2}|a{4,6}|bc"
+    assert str((parse("a") | parse("a*")).reduce()) == "a*"
 
 
 def test_bug_28_b():

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -326,18 +326,25 @@ def test_adotb():
 
 def test_rxelems_recursion_error():
     # Catch a recursion error
-    assert str(from_fsm(Fsm(
-        alphabet={"0", "1"},
-        states={0, 1, 2, 3},
-        initial=3,
-        finals={1},
-        map={
-            0: {"0": 1, "1": 1},
-            1: {"0": 2, "1": 2},
-            2: {"0": 2, "1": 2},
-            3: {"0": 0, "1": 2},
-        }
-    ))) == "0[01]"
+    assert (
+        str(
+            from_fsm(
+                Fsm(
+                    alphabet={"0", "1"},
+                    states={0, 1, 2, 3},
+                    initial=3,
+                    finals={1},
+                    map={
+                        0: {"0": 1, "1": 1},
+                        1: {"0": 2, "1": 2},
+                        2: {"0": 2, "1": 2},
+                        3: {"0": 0, "1": 2},
+                    },
+                )
+            )
+        )
+        == "0[01]"
+    )
 
 
 def test_even_star_bug1():
@@ -376,20 +383,22 @@ def test_binary_3():
     # Binary numbers divisible by 3.
     # Disallows the empty string
     # Allows "0" on its own, but not leading zeroes.
-    div3 = from_fsm(Fsm(
-        alphabet={"0", "1"},
-        states={"initial", "zero", 0, 1, 2, None},
-        initial="initial",
-        finals={"zero", 0},
-        map={
-            "initial": {"0": "zero", "1": 1},
-            "zero": {"0": None, "1": None},
-            0: {"0": 0, "1": 1},
-            1: {"0": 2, "1": 0},
-            2: {"0": 1, "1": 2},
-            None: {"0": None, "1": None},
-        },
-    ))
+    div3 = from_fsm(
+        Fsm(
+            alphabet={"0", "1"},
+            states={"initial", "zero", 0, 1, 2, None},
+            initial="initial",
+            finals={"zero", 0},
+            map={
+                "initial": {"0": "zero", "1": 1},
+                "zero": {"0": None, "1": None},
+                0: {"0": 0, "1": 1},
+                1: {"0": 2, "1": 0},
+                2: {"0": 1, "1": 2},
+                None: {"0": None, "1": None},
+            },
+        )
+    )
     assert str(parse("(0|1)").reduce()) == "[01]"
     assert str(parse("(0|12)").reduce()) == "0|12"
     assert str(parse("(0|1(01*0|10*1)*10*)").reduce()) == "0|1(01*0|10*1)*10*"
@@ -409,43 +418,30 @@ def test_base_N():
     base = 2
     N = 3
     assert base <= 10
-    divN = from_fsm(Fsm(
-        alphabet={str(i) for i in range(base)},
-        states=set(range(N)) | {"initial", "zero", None},
-        initial="initial",
-        finals={"zero", 0},
-        map=dict(
-            [
-                (
-                    "initial",
-                    dict(
-                        [(str(j), j % N) for j in range(1, base)]
-                        + [("0", "zero")]
-                    )
-                ),
-                (
-                    "zero",
-                    dict(
-                        [(str(j), None) for j in range(base)]
-                    )
-                ),
-                (
-                    None,
-                    dict(
-                        [(str(j), None) for j in range(base)]
-                    )
-                ),
-            ] + [
-                (
-                    i,
-                    dict(
-                        [(str(j), (i * base + j) % N) for j in range(base)]
-                    )
-                )
-                for i in range(N)
-            ]
-        ),
-    ))
+    divN = from_fsm(
+        Fsm(
+            alphabet={str(i) for i in range(base)},
+            states=set(range(N)) | {"initial", "zero", None},
+            initial="initial",
+            finals={"zero", 0},
+            map=dict(
+                [
+                    (
+                        "initial",
+                        dict(
+                            [(str(j), j % N) for j in range(1, base)] + [("0", "zero")]
+                        ),
+                    ),
+                    ("zero", dict([(str(j), None) for j in range(base)])),
+                    (None, dict([(str(j), None) for j in range(base)])),
+                ]
+                + [
+                    (i, dict([(str(j), (i * base + j) % N) for j in range(base)]))
+                    for i in range(N)
+                ]
+            ),
+        )
+    )
     gen = divN.strings()
     a = next(gen)
     assert a == "0"
@@ -473,18 +469,20 @@ def test_bad_alphabet():
 
 
 def test_dead_default():
-    blockquote = from_fsm(Fsm(
-        alphabet={"/", "*", ANYTHING_ELSE},
-        states={0, 1, 2, 3, 4},
-        initial=0,
-        finals={4},
-        map={
-            0: {"/": 1},
-            1: {"*": 2},
-            2: {"/": 2, ANYTHING_ELSE: 2, "*": 3},
-            3: {"/": 4, ANYTHING_ELSE: 2, "*": 3},
-        },
-    ))
+    blockquote = from_fsm(
+        Fsm(
+            alphabet={"/", "*", ANYTHING_ELSE},
+            states={0, 1, 2, 3, 4},
+            initial=0,
+            finals={4},
+            map={
+                0: {"/": 1},
+                1: {"*": 2},
+                2: {"/": 2, ANYTHING_ELSE: 2, "*": 3},
+                3: {"/": 4, ANYTHING_ELSE: 2, "*": 3},
+            },
+        )
+    )
     assert str(blockquote) == "/\\*([^*]|\\*+[^*/])*\\*+/"
 
 
@@ -925,8 +923,28 @@ def test_bug_slow():
     m = Fsm(
         alphabet={"R", "L", "U", "D"},
         states={
-            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-            11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+        },
         initial=0,
         finals={20},
         map={
@@ -961,15 +979,22 @@ def test_bug_slow():
 
 
 def test_bug_48_simpler():
-    assert str(from_fsm(Fsm(
-        alphabet={"d"},
-        states={0, 1},
-        initial=0,
-        finals={1},
-        map={
-            0: {"d": 1},
-        },
-    ))) == "d"
+    assert (
+        str(
+            from_fsm(
+                Fsm(
+                    alphabet={"d"},
+                    states={0, 1},
+                    initial=0,
+                    finals={1},
+                    map={
+                        0: {"d": 1},
+                    },
+                )
+            )
+        )
+        == "d"
+    )
 
 
 def test_bug_48():

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -303,8 +303,8 @@ def test_abstar():
         finals={0},
         map={
             0: {"a": 0, ANYTHING_ELSE: 1, "b": 0},
-            1: {"a": 1, ANYTHING_ELSE: 1, "b": 1}
-        }
+            1: {"a": 1, ANYTHING_ELSE: 1, "b": 1},
+        },
     )
     assert str(from_fsm(abstar)) == "[ab]*"
 
@@ -320,8 +320,8 @@ def test_adotb():
             1: {"a": 1, ANYTHING_ELSE: 1, "b": 1},
             2: {"a": 3, ANYTHING_ELSE: 3, "b": 3},
             3: {"a": 1, ANYTHING_ELSE: 1, "b": 4},
-            4: {"a": 1, ANYTHING_ELSE: 1, "b": 1}
-        }
+            4: {"a": 1, ANYTHING_ELSE: 1, "b": 1},
+        },
     )
     assert str(from_fsm(adotb)) == "a.b"
 
@@ -485,7 +485,7 @@ def test_dead_default():
             1: {"*": 2},
             2: {"/": 2, ANYTHING_ELSE: 2, "*": 3},
             3: {"/": 4, ANYTHING_ELSE: 2, "*": 3},
-        }
+        },
     ))
     assert str(blockquote) == "/\\*([^*]|\\*+[^*/])*\\*+/"
 
@@ -689,7 +689,7 @@ def test_parse_regex_intersection():
     assert str(parse("abc...") & parse("...def")) == "abcdef"
     assert str(parse("[bc]*[ab]*") & parse("[ab]*[bc]*")) in {
         "([ab]*a|[bc]*c)?b*",
-        "b*(a[ab]*|c[bc]*)?"
+        "b*(a[ab]*|c[bc]*)?",
     }
     assert str(parse("\\W*")) == "\\W*"
     assert str(parse("[a-g0-8$%\\^]+")) == "[$%0-8\\^a-g]+"
@@ -963,8 +963,8 @@ def test_bug_slow():
             17: {"D": 19},
             18: {"U": 19},
             19: {"L": 20},
-            20: {}
-        }
+            20: {},
+        },
     )
     t1 = time.time()
     ll = from_fsm(m)

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -15,9 +15,7 @@ from .rxelems import from_fsm
 # mypy: no-check-untyped-defs
 
 if __name__ == "__main__":
-    raise Exception(
-        "Test files can't be run directly. Use `python -m pytest greenery`"
-    )
+    raise Exception("Test files can't be run directly. Use `python -m pytest greenery`")
 
 
 ###############################################################################
@@ -705,24 +703,16 @@ def test_parse_regex_intersection():
     assert str(parse("[ab]{0,4}") & parse("[^a]{0,4}")) == "b{0,4}"
     assert str(parse("[abc]{0,8}") & parse("[^a]{0,8}")) == "[bc]{0,8}"
     assert (
-        str(parse("[a-g0-8$%\\^]{0,8}") & parse("[^d]{0,8}"))
-        == "[$%0-8\\^abcefg]{0,8}"
+        str(parse("[a-g0-8$%\\^]{0,8}") & parse("[^d]{0,8}")) == "[$%0-8\\^abcefg]{0,8}"
     )
-    assert (
-        str(parse("[a-g0-8$%\\^]+") & parse("[^d]{0,8}"))
-        == "[$%0-8\\^abcefg]{1,8}"
-    )
-    assert (
-        str(parse("[a-g0-8$%\\^]+") & parse("[^d]{2,8}"))
-        == "[$%0-8\\^abcefg]{2,8}"
-    )
+    assert str(parse("[a-g0-8$%\\^]+") & parse("[^d]{0,8}")) == "[$%0-8\\^abcefg]{1,8}"
+    assert str(parse("[a-g0-8$%\\^]+") & parse("[^d]{2,8}")) == "[$%0-8\\^abcefg]{2,8}"
     assert (
         str(parse("\\W*") & parse("[a-g0-8$%\\^]+") & parse("[^d]{2,8}"))
         == "[$%\\^]{2,8}"
     )
     assert (
-        str(parse("\\d{4}-\\d{2}-\\d{2}") & parse("19.*"))
-        == "19\\d{2}-\\d{2}-\\d{2}"
+        str(parse("\\d{4}-\\d{2}-\\d{2}") & parse("19.*")) == "19\\d{2}-\\d{2}-\\d{2}"
     )
 
 
@@ -828,15 +818,15 @@ def test_obvious_reduction():
 
 def test_mult_squoosh():
     # sequence squooshing of mults within a `Conc`
-    assert (
-        str(parse("[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]").reduce())
-        == "[0-9A-Fa-f]{3}"
-    )
+    assert str(parse("[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]").reduce()) == "[0-9A-Fa-f]{3}"
     assert str(parse("[$%\\^]?[$%\\^]").reduce()) == "[$%\\^]{1,2}"
     assert (
-        str(parse(
-            "(|(|(|(|(|[$%\\^])[$%\\^])[$%\\^])[$%\\^])[$%\\^])[$%\\^][$%\\^]"
-        ).reduce()) == "[$%\\^]{2,7}"
+        str(
+            parse(
+                "(|(|(|(|(|[$%\\^])[$%\\^])[$%\\^])[$%\\^])[$%\\^])[$%\\^][$%\\^]"
+            ).reduce()
+        )
+        == "[$%\\^]{2,7}"
     )
 
 
@@ -861,10 +851,7 @@ def test_epsilon_reduction():
 
 
 def test_charclass_intersection_2():
-    assert (
-        (parse("[A-z]") & parse("[^g]")).reduce()
-        == parse("[A-fh-z]").reduce()
-    )
+    assert (parse("[A-z]") & parse("[^g]")).reduce() == parse("[A-fh-z]").reduce()
 
 
 def test_reduce_boom():
@@ -986,9 +973,7 @@ def test_bug_48_simpler():
 
 
 def test_bug_48():
-    (
-        S5, S26, S45, S63, S80, S97, S113, S127, S140, S152, S163, S175, S182
-    ) = range(13)
+    S5, S26, S45, S63, S80, S97, S113, S127, S140, S152, S163, S175, S182 = range(13)
     char0, char1, char2, char3, char4, char5, char6, char7, char8 = (
         "_",
         "a",
@@ -1002,14 +987,8 @@ def test_bug_48():
     )
 
     machine = Fsm(
-        alphabet={
-            char0, char1, char2, char3, char4,
-            char5, char6, char7, char8
-        },
-        states={
-            S5, S26, S45, S63, S80, S97, S113,
-            S127, S140, S152, S163, S175, S182
-        },
+        alphabet={char0, char1, char2, char3, char4, char5, char6, char7, char8},
+        states={S5, S26, S45, S63, S80, S97, S113, S127, S140, S152, S163, S175, S182},
         initial=S5,
         finals={S182},
         map={

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -704,16 +704,26 @@ def test_parse_regex_intersection():
     assert str(parse("[ab]{0,2}") & parse("[^a]{0,2}")) == "b{0,2}"
     assert str(parse("[ab]{0,4}") & parse("[^a]{0,4}")) == "b{0,4}"
     assert str(parse("[abc]{0,8}") & parse("[^a]{0,8}")) == "[bc]{0,8}"
-    assert str(parse("[a-g0-8$%\\^]{0,8}") & parse("[^d]{0,8}")) \
+    assert (
+        str(parse("[a-g0-8$%\\^]{0,8}") & parse("[^d]{0,8}"))
         == "[$%0-8\\^abcefg]{0,8}"
-    assert str(parse("[a-g0-8$%\\^]+") & parse("[^d]{0,8}")) \
+    )
+    assert (
+        str(parse("[a-g0-8$%\\^]+") & parse("[^d]{0,8}"))
         == "[$%0-8\\^abcefg]{1,8}"
-    assert str(parse("[a-g0-8$%\\^]+") & parse("[^d]{2,8}")) \
+    )
+    assert (
+        str(parse("[a-g0-8$%\\^]+") & parse("[^d]{2,8}"))
         == "[$%0-8\\^abcefg]{2,8}"
-    assert str(parse("\\W*") & parse("[a-g0-8$%\\^]+") & parse("[^d]{2,8}")) \
+    )
+    assert (
+        str(parse("\\W*") & parse("[a-g0-8$%\\^]+") & parse("[^d]{2,8}"))
         == "[$%\\^]{2,8}"
-    assert str(parse("\\d{4}-\\d{2}-\\d{2}") & parse("19.*")) \
+    )
+    assert (
+        str(parse("\\d{4}-\\d{2}-\\d{2}") & parse("19.*"))
         == "19\\d{2}-\\d{2}-\\d{2}"
+    )
 
 
 def test_complexify():
@@ -738,11 +748,12 @@ def test_complexify():
 def test_silly_reduction():
     # This one is horrendous and we have to jump through some hoops to get to
     # a sensible result. Probably not a good unit test actually.
-    long = \
-        "(aa|bb*aa)a*|((ab|bb*ab)|(aa|bb*aa)a*b)" \
-        + "((ab|bb*ab)|(aa|bb*aa)a*b)*" \
-        + "(aa|bb*aa)a*|((ab|bb*ab)|(aa|bb*aa)a*b)" \
+    long = (
+        "(aa|bb*aa)a*|((ab|bb*ab)|(aa|bb*aa)a*b)"
         + "((ab|bb*ab)|(aa|bb*aa)a*b)*"
+        + "(aa|bb*aa)a*|((ab|bb*ab)|(aa|bb*aa)a*b)"
+        + "((ab|bb*ab)|(aa|bb*aa)a*b)*"
+    )
     long = parse(long)
     long = long.to_fsm().reversed()
     long = from_fsm(long).reversed()
@@ -817,13 +828,16 @@ def test_obvious_reduction():
 
 def test_mult_squoosh():
     # sequence squooshing of mults within a `Conc`
-    assert str(parse("[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]").reduce()) \
+    assert (
+        str(parse("[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]").reduce())
         == "[0-9A-Fa-f]{3}"
+    )
     assert str(parse("[$%\\^]?[$%\\^]").reduce()) == "[$%\\^]{1,2}"
-    assert str(parse(
-        "(|(|(|(|(|[$%\\^])[$%\\^])[$%\\^])[$%\\^])[$%\\^])[$%\\^][$%\\^]"
-    ).reduce()) \
-        == "[$%\\^]{2,7}"
+    assert (
+        str(parse(
+            "(|(|(|(|(|[$%\\^])[$%\\^])[$%\\^])[$%\\^])[$%\\^])[$%\\^][$%\\^]"
+        ).reduce()) == "[$%\\^]{2,7}"
+    )
 
 
 def test_bad_reduction_bug():
@@ -847,8 +861,10 @@ def test_epsilon_reduction():
 
 
 def test_charclass_intersection_2():
-    assert (parse("[A-z]") & parse("[^g]")).reduce() \
+    assert (
+        (parse("[A-z]") & parse("[^g]")).reduce()
         == parse("[A-fh-z]").reduce()
+    )
 
 
 def test_reduce_boom():
@@ -970,10 +986,20 @@ def test_bug_48_simpler():
 
 
 def test_bug_48():
-    S5, S26, S45, S63, S80, S97, S113, S127, S140, S152, S163, S175, S182 = \
-        range(13)
-    char0, char1, char2, char3, char4, char5, char6, char7, char8 = \
-        "_", "a", "d", "e", "g", "m", "n", "o", "p"
+    (
+        S5, S26, S45, S63, S80, S97, S113, S127, S140, S152, S163, S175, S182
+    ) = range(13)
+    char0, char1, char2, char3, char4, char5, char6, char7, char8 = (
+        "_",
+        "a",
+        "d",
+        "e",
+        "g",
+        "m",
+        "n",
+        "o",
+        "p",
+    )
 
     machine = Fsm(
         alphabet={

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,25 @@ setup(
     author_email="qntm <qntm@users.noreply.github.com>",
     description="Greenery allows manipulation of regular expressions",
     license="MIT License",
-    keywords=" ".join([
-        "re", "regex", "regexp", "regular", "expression", "deterministic",
-        "finite", "state", "machine", "automaton", "fsm", "dfsm", "fsa",
-        "dfsa", "greenery",
-    ]),
+    keywords=" ".join(
+        [
+            "re",
+            "regex",
+            "regexp",
+            "regular",
+            "expression",
+            "deterministic",
+            "finite",
+            "state",
+            "machine",
+            "automaton",
+            "fsm",
+            "dfsm",
+            "fsa",
+            "dfsa",
+            "greenery",
+        ]
+    ),
     url="https://github.com/qntm/greenery",
     classifiers=[
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,7 @@ setup(
     version="4.0.0",
     tests_require=["pytest"],
     packages=["greenery"],
-    package_dir={
-        "greenery": "greenery"
-    },
+    package_dir={"greenery": "greenery"},
     author="qntm",
     author_email="qntm <qntm@users.noreply.github.com>",
     description="Greenery allows manipulation of regular expressions",


### PR DESCRIPTION
This integrates the [`black` auto-formatter](https://github.com/psf/black#used-by). It updates the formatting incrementally (mainly to assist branch maintenance via git's recursive merge) and then adds it to the CI steps.

Note that this branch is based on the flake8/pycodestyle fixup PR #79, and the narrower difference between them can be viewed here: https://github.com/qntm/greenery/compare/rwe:flake8...rwe:black?expand=1 
If this PR merges first, that one will auto-close.

Although `black`'s formatting rules aren't always what I would want (e.g. its treatment of nested function calls across lines), the benefits of a single "format this" command, e.g. when resolving merges, is quite high. `black` is used very widely in high-profile projects:
  * https://github.com/psf/black#used-by

@qntm I recognize this type of change is at high risk of difference-of-opinion, so my earlier comment applies, that these PRs are made without expectation.