### PR TITLE
fsm: add translation layer between symbol and transition

### DIFF
--- a/greenery/alpha_test.py
+++ b/greenery/alpha_test.py
@@ -1,0 +1,81 @@
+from .alphabet import Alphabet, ANYTHING_ELSE
+
+
+def test_distinct():
+    alpha = Alphabet.distinct({'a', 'b', 'c', ANYTHING_ELSE})
+    assert len(alpha) == 4
+    assert len(alpha.events) == 4
+    seen = set()
+    for letter in {'a', 'b', 'c', ANYTHING_ELSE}:
+        assert alpha[letter] not in seen
+        seen.add(alpha[letter])
+
+
+def test_groupings():
+    groups = tuple(map(tuple, ("abc", "def", "ghi", ("j", ANYTHING_ELSE))))
+    alpha = Alphabet.groups(*groups)
+    assert len(alpha) == (3 + 3 + 3 + 2)
+    assert len(alpha.events) == 4
+    for event, symbols in alpha.events.items():
+        assert tuple(sorted(symbols)) in groups
+        for sym in symbols:
+            assert alpha[sym] == event
+
+
+def test_union():
+    a = Alphabet.groups("abc", "def")
+    b = Alphabet.groups("ab", "cd", "ef")
+    u, new_to_olds = a.union(b)
+    assert len(u.events) == 4
+    assert len(u) == 6
+    for group in ("ab", "c", "d", "ef"):
+        expected = u[group[0]]
+        for sym in group:
+            assert expected == u[sym]
+            for old, new_to_old in zip((a, b), new_to_olds):
+                assert new_to_old[u[sym]] == old[sym]
+
+
+def test_union_incomplete():
+    a = Alphabet.groups("abc", "d")
+    b = Alphabet.groups("cd", "ef")
+    u, new_to_olds = a.union(b)
+    assert len(u.events) == 4
+    assert len(u) == 6
+    for group in ("ab", "c", "d", "ef"):
+        expected = u[group[0]]
+        for sym in group:
+            assert expected == u[sym]
+            for old, new_to_old in zip((a, b), new_to_olds):
+                if sym in old:
+                    assert new_to_old[u[sym]] == old[sym]
+
+
+def test_union_anything_else():
+    a = Alphabet.groups("abc", "d", (ANYTHING_ELSE,))
+    b = Alphabet.groups("cd", "ef")
+    u, new_to_olds = a.union(b)
+    assert len(u.events) == 5
+    assert len(u) == 7
+    for group in ("ab", "c", "d", "ef", (ANYTHING_ELSE,), '?'):
+        expected = u[group[0]]
+        for sym in group:
+            assert expected == u[sym]
+            for old, new_to_old in zip((a, b), new_to_olds):
+                if sym in old:
+                    assert new_to_old[u[sym]] == old[sym]
+
+
+def test_union_anything_else_2():
+    a = Alphabet.groups("abc", "d", (ANYTHING_ELSE,))
+    b = Alphabet.groups("cd", "ef", (ANYTHING_ELSE,))
+    u, new_to_olds = a.union(b)
+    assert len(u.events) == 5
+    assert len(u) == 7
+    for group in ("ab", "c", "d", "ef", (ANYTHING_ELSE,), '?'):
+        expected = u[group[0]]
+        for sym in group:
+            assert expected == u[sym]
+            for old, new_to_old in zip((a, b), new_to_olds):
+                if sym in old:
+                    assert new_to_old[u[sym]] == old[sym]

--- a/greenery/alphabet.py
+++ b/greenery/alphabet.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Mapping, Union, Any, Iterator
+from enum import Enum, auto
+from functools import total_ordering
+
+
+@total_ordering
+class AnythingElse(Enum):
+    """
+    This is a surrogate symbol which you can use in your finite state
+    machines to represent "any symbol not in the official alphabet". For
+    example, if your state machine's alphabet is `{"a", "b", "c", "d",
+    fsm.ANYTHING_ELSE}`, then if "e" is passed as a symbol, it will be
+    converted to `fsm.ANYTHING_ELSE` before following the appropriate
+    transition.
+
+    This is an `Enum` to enforce a singleton value, detectable by type
+    checkers, as described in:
+    https://www.python.org/dev/peps/pep-0484/#support-for-singleton-types-in-unions
+    """
+
+    TOKEN = auto()
+
+    def __lt__(self, _: Any, /) -> bool:
+        """Ensure `fsm.ANYTHING_ELSE` always sorts last"""
+        return False
+
+    def __eq__(self, other: Any, /) -> bool:
+        return self is other
+
+    def __hash__(self, /) -> int:
+        return hash(type(self))
+
+    def __str__(self, /) -> str:
+        return "ANYTHING_ELSE"
+
+    def __repr__(self, /) -> str:
+        return "ANYTHING_ELSE"
+
+
+ANYTHING_ELSE = AnythingElse.TOKEN
+alpha_type = Union[str, AnythingElse]
+event_type = int
+
+
+class Alphabet(Mapping[alpha_type, event_type]):
+    """ Represents an Alphabet for an FSM. It maps symbols to events."""
+
+    def __init__(self, symbol_to_event: dict[alpha_type, int]):
+        self._symbol_to_event = symbol_to_event
+        event_to_symbol = defaultdict(list)
+        for s, t in symbol_to_event.items():
+            event_to_symbol[t].append(s)
+        self._event_to_symbol = {t: tuple(s) for t, s in event_to_symbol.items()}
+
+    def __repr__(self):
+        return f"{type(self).__name__}({self._symbol_to_event!r})"
+
+    def __getitem__(self, k: alpha_type) -> event_type:
+        if k in self._symbol_to_event:
+            return self._symbol_to_event[k]
+        elif ANYTHING_ELSE in self._symbol_to_event:
+            return self._symbol_to_event[ANYTHING_ELSE]
+        else:
+            raise KeyError(k)
+
+    def __len__(self) -> int:
+        return len(self._symbol_to_event)
+
+    def __iter__(self) -> Iterator[alpha_type]:
+        return iter(self._symbol_to_event)
+
+    def __eq__(self, other):
+        if isinstance(other, Alphabet):
+            return self._symbol_to_event == other._symbol_to_event
+
+    @property
+    def events(self):
+        return self._event_to_symbol
+
+    @classmethod
+    def distinct(cls, s: set):
+        """ For convenience, the resulting instance behaves like an old-style alphabet"""
+        return cls(dict(zip(s, range(len(s)))))
+
+    def union(*alphabets: Alphabet) -> tuple[Alphabet, tuple[dict[event_type, event_type | None]]]:
+        """
+        Creates the union Alphabet from two alphabets.
+        Also returns a mapping for each input alphabet mapping new event to old event (many-to-one)
+        """
+        #   Terminology
+        # symbol           - an individual input character or ANYTHING_ELSE
+        # events (plural)  - The combination of all events from each of the independent alphabets
+        # new_event        - The new event that the symbol(s) got mapped to
+        # old_event        - The old event that the events belongs to
+
+        all_symbols = set().union(*(a._symbol_to_event.keys() for a in alphabets))
+
+        symbol_to_events = {symbol: tuple(a.get(symbol) for a in alphabets) for symbol in all_symbols}
+
+        events_to_symbols = defaultdict(list)
+        for symbol, events in symbol_to_events.items():
+            events_to_symbols[events].append(symbol)
+        events_to_new_event = {k: i for i, k in enumerate(events_to_symbols)}
+        result = Alphabet({symbol: events_to_new_event[events]
+                           for events, symbols in events_to_symbols.items()
+                           for symbol in symbols})
+
+        new_to_old_mappings = [{} for _ in alphabets]
+        for events, new_event in events_to_new_event.items():
+            for old_event, new_to_old in zip(events, new_to_old_mappings):
+                new_to_old[new_event] = old_event
+        return result, tuple(new_to_old_mappings)

--- a/greenery/alphabet.py
+++ b/greenery/alphabet.py
@@ -91,6 +91,12 @@ class Alphabet(Mapping[alpha_type, event_type]):
                     for i, group in enumerate(equal_groups)
                     for sym in (group if group != ANYTHING_ELSE else (group,))})
 
+    def with_anything_else(self):
+        if ANYTHING_ELSE in self._symbol_to_event:
+            return self
+        else:
+            return Alphabet({**self._symbol_to_event, ANYTHING_ELSE: 1 + max(self._symbol_to_event.values(), default=-1)})
+
     def union(*alphabets: Alphabet) -> tuple[Alphabet, tuple[dict[event_type, Union[event_type, None]], ...]]:
         """
         Creates the union Alphabet from two alphabets.

--- a/greenery/alphabet.py
+++ b/greenery/alphabet.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Mapping, Union, Any, Iterator
+from typing import Mapping, Union, Any, Iterator, Iterable, Sequence
 from enum import Enum, auto
 from functools import total_ordering
 
@@ -80,9 +80,16 @@ class Alphabet(Mapping[alpha_type, event_type]):
         return self._event_to_symbol
 
     @classmethod
-    def distinct(cls, s: set):
+    def distinct(cls, s: Iterable[alpha_type]):
         """ For convenience, the resulting instance behaves like an old-style alphabet"""
-        return cls(dict(zip(s, range(len(s)))))
+        return cls({sym: i for i, sym in enumerate(s)})
+
+    @classmethod
+    def groups(cls, *equal_groups: Iterable[alpha_type] | AnythingElse):
+        """ Each parameter gets turned into its own event"""
+        return cls({sym: i
+                    for i, group in enumerate(equal_groups)
+                    for sym in (group if group != ANYTHING_ELSE else (group,))})
 
     def union(*alphabets: Alphabet) -> tuple[Alphabet, tuple[dict[event_type, Union[event_type, None]], ...]]:
         """

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -193,7 +193,7 @@ class Charclass:
                 0: dict([(symbol, 1) for symbol in self.chars]),
             }
 
-        return Fsm(
+        return Fsm.via_symbols(
             alphabet=alphabet,
             states={0, 1},
             initial=0,

--- a/greenery/charclass_test.py
+++ b/greenery/charclass_test.py
@@ -69,7 +69,7 @@ def test_charclass_str():
 def test_charclass_fsm():
     # "[^a]"
     nota = (~Charclass("a")).to_fsm()
-    assert nota.alphabet == {"a", ANYTHING_ELSE}
+    assert set(nota.alphabet) == {"a", ANYTHING_ELSE}
     assert nota.accepts("b")
     assert nota.accepts(["b"])
     assert nota.accepts([ANYTHING_ELSE])

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -13,7 +13,7 @@ from .fsm import ANYTHING_ELSE, AnythingElse, Fsm, epsilon, null
 
 def test_addbug():
     # Odd bug with Fsm.__add__(), exposed by "[bc]*c"
-    int5A = Fsm(
+    int5A = Fsm.via_symbols(
         alphabet={"a", "b", "c", ANYTHING_ELSE},
         states={0, 1},
         initial=1,
@@ -25,7 +25,7 @@ def test_addbug():
     )
     assert int5A.accepts("")
 
-    int5B = Fsm(
+    int5B = Fsm.via_symbols(
         alphabet={"a", "b", "c", ANYTHING_ELSE},
         states={0, 1, 2},
         initial=1,
@@ -51,7 +51,7 @@ def test_builtins():
 
 @pytest.fixture
 def a():
-    a = Fsm(
+    a = Fsm.via_symbols(
         alphabet={"a", "b"},
         states={0, 1, "ob"},
         initial=0,
@@ -73,7 +73,7 @@ def test_a(a):
 
 @pytest.fixture
 def b():
-    b = Fsm(
+    b = Fsm.via_symbols(
         alphabet={"a", "b"},
         states={0, 1, "ob"},
         initial=0,
@@ -218,7 +218,7 @@ def test_crawl_reduction():
     # states 1 and 2&3 also behave identically, so they, too should be resolved
     # (this is impossible to spot before 2 and 3 have been combined).
     # Finally, the oblivion state should be omitted.
-    merged = Fsm(
+    merged = Fsm.via_symbols(
         alphabet={"0", "1"},
         states={1, 2, 3, 4, "oblivion"},
         initial=1,
@@ -236,7 +236,7 @@ def test_crawl_reduction():
 
 def test_bug_28():
     # This is (ab*)* and it caused some defects.
-    abstar = Fsm(
+    abstar = Fsm.via_symbols(
         alphabet={"a", "b"},
         states={0, 1},
         initial=0,
@@ -260,7 +260,7 @@ def test_bug_28():
 def test_star_advanced():
     # This is (a*ba)*. Naively connecting the final states to the initial state
     # gives the incorrect result here.
-    starred = Fsm(
+    starred = Fsm.via_symbols(
         alphabet={"a", "b"},
         states={0, 1, 2, "oblivion"},
         initial=0,
@@ -286,7 +286,7 @@ def test_star_advanced():
 
 def test_reduce():
     # FSM accepts no strings but has 3 states, needs only 1
-    asdf = Fsm(
+    asdf = Fsm.via_symbols(
         alphabet={None},
         states={0, 1, 2},
         initial=0,
@@ -302,7 +302,7 @@ def test_reduce():
 
 
 def test_reverse_abc():
-    abc = Fsm(
+    abc = Fsm.via_symbols(
         alphabet={"a", "b", "c"},
         states={0, 1, 2, 3, None},
         initial=0,
@@ -321,7 +321,7 @@ def test_reverse_abc():
 
 def test_reverse_brzozowski():
     # This is (a|b)*a(a|b)
-    brzozowski = Fsm(
+    brzozowski = Fsm.via_symbols(
         alphabet={"a", "b"},
         states={"A", "B", "C", "D", "E"},
         initial="A",
@@ -380,7 +380,7 @@ def test_binary_3():
     # Binary numbers divisible by 3.
     # Disallows the empty string
     # Allows "0" on its own, but not leading zeroes.
-    div3 = Fsm(
+    div3 = Fsm.via_symbols(
         alphabet={"0", "1"},
         states={"initial", "zero", 0, 1, 2, None},
         initial="initial",
@@ -424,7 +424,7 @@ def test_binary_3():
 def test_invalid_fsms():
     # initial state 1 is not a state
     with pytest.raises(Exception, match="Initial state"):
-        Fsm(
+        Fsm.via_symbols(
             alphabet={},
             states={},
             initial=1,
@@ -434,7 +434,7 @@ def test_invalid_fsms():
 
     # final state 2 not a state
     with pytest.raises(Exception, match="Final states"):
-        Fsm(
+        Fsm.via_symbols(
             alphabet={},
             states={1},
             initial=1,
@@ -444,7 +444,7 @@ def test_invalid_fsms():
 
     # invalid transition for state 1, symbol "a"
     with pytest.raises(Exception, match="Transition.+leads to.+not a state"):
-        Fsm(
+        Fsm.via_symbols(
             alphabet={"a"},
             states={1},
             initial=1,
@@ -456,7 +456,7 @@ def test_invalid_fsms():
 
     # invalid transition from unknown state
     with pytest.raises(Exception, match="Transition.+unknown state"):
-        Fsm(
+        Fsm.via_symbols(
             alphabet={"a"},
             states={1, 2},
             initial=1,
@@ -468,7 +468,7 @@ def test_invalid_fsms():
 
     # invalid transition table includes symbol outside of alphabet
     with pytest.raises(Exception, match="Invalid symbol"):
-        Fsm(
+        Fsm.via_symbols(
             alphabet={"a"},
             states={1, 2},
             initial=1,
@@ -483,7 +483,7 @@ def test_bad_multiplier(a):
 
 
 def test_anything_else_acceptance():
-    a = Fsm(
+    a = Fsm.via_symbols(
         alphabet={"a", "b", "c", ANYTHING_ELSE},
         states={1},
         initial=1,
@@ -496,7 +496,7 @@ def test_anything_else_acceptance():
 
 
 def test_difference(a, b):
-    aorb = Fsm(
+    aorb = Fsm.via_symbols(
         alphabet={"a", "b"},
         states={0, 1, None},
         initial=0,
@@ -518,7 +518,7 @@ def test_empty(a, b):
     assert not a.empty()
     assert not b.empty()
 
-    assert Fsm(
+    assert Fsm.via_symbols(
         alphabet={},
         states={0, 1},
         initial=0,
@@ -526,7 +526,7 @@ def test_empty(a, b):
         map={0: {}, 1: {}},
     ).empty()
 
-    assert not Fsm(
+    assert not Fsm.via_symbols(
         alphabet={},
         states={0},
         initial=0,
@@ -534,7 +534,7 @@ def test_empty(a, b):
         map={0: {}},
     ).empty()
 
-    assert Fsm(
+    assert Fsm.via_symbols(
         alphabet={"a", "b"},
         states={0, 1, None, 2},
         initial=0,
@@ -557,7 +557,7 @@ def test_dead_default():
     You may now omit a transition, or even an entire state, from the map.
     This affects every usage of `Fsm.map`.
     """
-    blockquote = Fsm(
+    blockquote = Fsm.via_symbols(
         alphabet={"/", "*", ANYTHING_ELSE},
         states={0, 1, 2, 3, 4, 5},
         initial=0,
@@ -600,7 +600,7 @@ def test_dead_default():
 def test_alphabet_unions():
     # Thanks to sparse maps it should now be possible to compute the union of
     # FSMs with disagreeing alphabets!
-    a = Fsm(
+    a = Fsm.via_symbols(
         alphabet={"a"},
         states={0, 1},
         initial=0,
@@ -610,7 +610,7 @@ def test_alphabet_unions():
         },
     )
 
-    b = Fsm(
+    b = Fsm.via_symbols(
         alphabet={"b"},
         states={0, 1},
         initial=0,
@@ -695,7 +695,7 @@ def test_new_set_methods(a, b):
 def test_oblivion_crawl(a):
     # When crawling a new FSM, we should avoid generating an oblivion state.
     # `abc` has no oblivion state... all the results should not as well!
-    abc = Fsm(
+    abc = Fsm.via_symbols(
         alphabet={"a", "b", "c"},
         states={0, 1, 2, 3},
         initial=0,
@@ -735,7 +735,7 @@ def test_derive(a, b):
 
 
 def test_bug_36():
-    etc1 = Fsm(
+    etc1 = Fsm.via_symbols(
         alphabet={ANYTHING_ELSE},
         states={0},
         initial=0,
@@ -746,7 +746,7 @@ def test_bug_36():
             }
         }
     )
-    etc2 = Fsm(
+    etc2 = Fsm.via_symbols(
         alphabet={"s", ANYTHING_ELSE},
         states={0, 1},
         initial=0,
@@ -770,7 +770,7 @@ def test_bug_36():
 
 def test_add_anything_else():
     # [^a]
-    fsm1 = Fsm(
+    fsm1 = Fsm.via_symbols(
         alphabet={"a", ANYTHING_ELSE},
         states={0, 1},
         initial=0,
@@ -779,7 +779,7 @@ def test_add_anything_else():
     )
 
     # [^b]
-    fsm2 = Fsm(
+    fsm2 = Fsm.via_symbols(
         alphabet={"b", ANYTHING_ELSE},
         states={0, 1},
         initial=0,
@@ -839,7 +839,7 @@ def test_anything_else_sorts_after(val):
 
 def test_anything_else_pickle():
     # [^z]
-    fsm1 = Fsm(
+    fsm1 = Fsm.via_symbols(
         alphabet={"z", ANYTHING_ELSE},
         states={0, 1},
         initial=0,

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -272,7 +272,7 @@ def test_star_advanced():
             "oblivion": {"a": "oblivion", "b": "oblivion"},
         }
     ).star()
-    assert starred.alphabet == frozenset(["a", "b"])
+    assert frozenset(starred.alphabet.keys()) == frozenset(["a", "b"])
     assert starred.accepts("")
     assert not starred.accepts("a")
     assert not starred.accepts("b")
@@ -764,7 +764,7 @@ def test_bug_36():
     both = etc1 & etc2
     assert etc1.accepts(["s"])
     assert etc2.accepts(["s"])
-    assert both.alphabet == {ANYTHING_ELSE, "s"}
+    assert set(both.alphabet) == {ANYTHING_ELSE, "s"}
     assert both.accepts(["s"])
 
 

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -322,8 +322,8 @@ def from_fsm(f: Fsm) -> Pattern:
     while i < len(states):
         current = states[i]
         if current in f.map:
-            for symbol in sorted(f.map[current]):
-                next = f.map[current][symbol]
+            for event in sorted(f.map[current]):
+                next = f.map[current][event]
                 if next not in states:
                     states.append(next)
         i += 1
@@ -343,14 +343,14 @@ def from_fsm(f: Fsm) -> Pattern:
 
     # Populate it with some initial data.
     for a in f.map:
-        for symbol in f.map[a]:
-            b = f.map[a][symbol]
-            if symbol is ANYTHING_ELSE:
+        for event in f.map[a]:
+            b = f.map[a][event]
+            if ANYTHING_ELSE in f.alphabet.events[event]:
                 charclass = ~Charclass(
-                    frozenset(s for s in f.alphabet if s is not ANYTHING_ELSE)
+                    frozenset(s for s in f.alphabet if s not in f.alphabet.events[event])
                 )
             else:
-                charclass = Charclass(frozenset((symbol,)))
+                charclass = Charclass(frozenset(f.alphabet.events[event]))
 
             brz[a][b] = Pattern(
                 *brz[a][b].concs,

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -297,7 +297,7 @@ def test_dot():
 
 def test_abstar():
     # Buggggs.
-    abstar = Fsm(
+    abstar = Fsm.via_symbols(
         alphabet={"a", ANYTHING_ELSE, "b"},
         states={0, 1},
         initial=0,
@@ -311,7 +311,7 @@ def test_abstar():
 
 
 def test_adotb():
-    adotb = Fsm(
+    adotb = Fsm.via_symbols(
         alphabet={"a", ANYTHING_ELSE, "b"},
         states={0, 1, 2, 3, 4},
         initial=0,
@@ -329,7 +329,7 @@ def test_adotb():
 
 def test_rxelems_recursion_error():
     # Catch a recursion error
-    assert str(from_fsm(Fsm(
+    assert str(from_fsm(Fsm.via_symbols(
         alphabet={"0", "1"},
         states={0, 1, 2, 3},
         initial=3,
@@ -347,7 +347,7 @@ def test_even_star_bug1():
     # Bug fix. This is a(a{2})* (i.e. accepts an odd number of "a" chars in a
     # row), but when from_fsm() is called, the result is "a+". Turned out to be
     # a fault in the rxelems.multiplier.__mul__() routine
-    elesscomplex = Fsm(
+    elesscomplex = Fsm.via_symbols(
         alphabet={"a"},
         states={0, 1},
         initial=0,
@@ -379,7 +379,7 @@ def test_binary_3():
     # Binary numbers divisible by 3.
     # Disallows the empty string
     # Allows "0" on its own, but not leading zeroes.
-    div3 = from_fsm(Fsm(
+    div3 = from_fsm(Fsm.via_symbols(
         alphabet={"0", "1"},
         states={"initial", "zero", 0, 1, 2, None},
         initial="initial",
@@ -412,7 +412,7 @@ def test_base_N():
     base = 2
     N = 3
     assert base <= 10
-    divN = from_fsm(Fsm(
+    divN = from_fsm(Fsm.via_symbols(
         alphabet=set(str(i) for i in range(base)),
         states=set(range(N)) | {"initial", "zero", None},
         initial="initial",
@@ -463,7 +463,7 @@ def test_bad_alphabet():
     # convert it to an `rxelems` object then the only acceptable symbols are
     # single characters or `ANYTHING_ELSE`.
     for bad_symbol in [None, (), 0, ("a",), "", "aa", "ab", True]:
-        f = Fsm(
+        f = Fsm.via_symbols(
             alphabet={bad_symbol},
             states={0},
             initial=0,
@@ -478,7 +478,7 @@ def test_bad_alphabet():
 
 
 def test_dead_default():
-    blockquote = from_fsm(Fsm(
+    blockquote = from_fsm(Fsm.via_symbols(
         alphabet={"/", "*", ANYTHING_ELSE},
         states={0, 1, 2, 3, 4},
         initial=0,
@@ -953,7 +953,7 @@ def test_isdisjoint():
 
 def test_bug_slow():
     # issue #43
-    m = Fsm(
+    m = Fsm.via_symbols(
         alphabet={"R", "L", "U", "D"},
         states={
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
@@ -992,7 +992,7 @@ def test_bug_slow():
 
 
 def test_bug_48_simpler():
-    assert str(from_fsm(Fsm(
+    assert str(from_fsm(Fsm.via_symbols(
         alphabet={"d"},
         states={0, 1},
         initial=0,
@@ -1009,7 +1009,7 @@ def test_bug_48():
     char0, char1, char2, char3, char4, char5, char6, char7, char8 = \
         "_", "a", "d", "e", "g", "m", "n", "o", "p"
 
-    machine = Fsm(
+    machine = Fsm.via_symbols(
         alphabet={
             char0, char1, char2, char3, char4,
             char5, char6, char7, char8

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -49,7 +49,7 @@ def test_parse_str_round_trip():
 
 def test_alphabet():
     # `.alphabet()` should include `ANYTHING_ELSE`
-    assert parse("").alphabet() == {ANYTHING_ELSE}
+    assert set(parse("").alphabet()) == {ANYTHING_ELSE}
 
 
 def test_pattern_fsm():


### PR DESCRIPTION
This is work towards fixing #81 . Most of the work for this I was doing for interegular anyway already, so it was quite a bit of copy/paste. (Note that the `Alphabet` class doesn't implement ranges right now, so it right now doesn't fix #81 at all).

The core idea behind this rework is to differentiate between the inputs and the transitions by splitting up the two roles string played till now into `symbol` and `event`. The `Alphabet` class takes in symbols and maps them to events. The core functionally of this class is however the `.union` operation that takes in multiple `Alphabet`s and joins them together in an efficient way so that the number of events needed is minimal. Depending on the original regex(es) this can improve performance of some operations by an order of magnitude.

I am not sure about the name `event`. If someone has a better idea, I am all ears. I also considered `transition` or `key` or `transition_key`, but they all don't seem any better IMO.

A lot of these changes are renaming variables or changing `Fsm(` to `Fsm.via_symbols(`, so this PR looks a lot larger than it actually is.


TODO:

- [ ] tests for `Alphabet` (based on existing convention in `alphabet_test.py`
- [ ] Add correct `Alphabet` generation into the various patterns
- [ ] Add range support to `Alphabet` to actually fix #81 (this potentially means adding another new class `SymbolList` or similar)


I would like some general feedback if the current path is something that has a chance to be merged.