### PR TITLE
Charclass: type signatures and fixed types

### DIFF
--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -51,12 +51,12 @@ class Charclass:
         object.__setattr__(self, "chars", chars)
         object.__setattr__(self, "negated", negated)
 
-    def __eq__(self, other):
+    def __eq__(self, other, /):
         return isinstance(other, Charclass) \
             and self.chars == other.chars \
             and self.negated == other.negated
 
-    def __hash__(self):
+    def __hash__(self, /):
         return hash((self.chars, self.negated))
 
     # These are the characters carrying special meanings when they appear
@@ -90,7 +90,7 @@ class Charclass:
         s: "\\S",
     }
 
-    def __str__(self):
+    def __str__(self, /):
         # e.g. \w
         if self in shorthand.keys():
             return shorthand[self]
@@ -122,8 +122,8 @@ class Charclass:
         # multiple characters (or possibly 0 characters)
         return "[" + self.escape() + "]"
 
-    def escape(self):
-        def escapeChar(char):
+    def escape(self, /):
+        def escapeChar(char, /):
             if char in Charclass.classSpecial:
                 return "\\" + char
             if char in escapes.keys():
@@ -180,7 +180,7 @@ class Charclass:
 
         return output
 
-    def to_fsm(self, alphabet=None):
+    def to_fsm(self, /, alphabet=None):
         alphabet = self.alphabet() if alphabet is None else frozenset(alphabet)
 
         # 0 is initial, 1 is final
@@ -205,7 +205,7 @@ class Charclass:
             map=map,
         )
 
-    def __repr__(self):
+    def __repr__(self, /):
         string = ""
         if self.negated is True:
             string += "~"
@@ -216,31 +216,31 @@ class Charclass:
         string += ")"
         return string
 
-    def reduce(self):
+    def reduce(self, /):
         # `Charclass`es cannot be reduced.
         return self
 
-    def alphabet(self):
+    def alphabet(self, /):
         return self.chars | {ANYTHING_ELSE}
 
-    def empty(self):
+    def empty(self, /):
         return len(self.chars) == 0 and not self.negated
 
     # set operations
-    def negate(self):
+    def negate(self, /):
         """
         Negate the current `Charclass`. e.g. [ab] becomes [^ab]. Call
         using "charclass2 = ~charclass1"
         """
         return Charclass(self.chars, negated=not self.negated)
 
-    def __invert__(self):
+    def __invert__(self, /):
         return self.negate()
 
-    def reversed(self):
+    def reversed(self, /):
         return self
 
-    def __or__(self, other):
+    def __or__(self, other, /):
         # ¬A OR ¬B = ¬(A AND B)
         # ¬A OR B = ¬(A - B)
         # A OR ¬B = ¬(B - A)

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -44,6 +44,8 @@ class Charclass:
         for c in self.chars:
             if not isinstance(c, str):
                 raise TypeError(f"Can't put {c!r} in a `Charclass`", c)
+            if len(c) != 1:
+                raise ValueError("`Charclass` can only contain single chars", c)
 
     def __eq__(self, other):
         return isinstance(other, Charclass) \

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -62,14 +62,14 @@ class Charclass:
     # These are the characters carrying special meanings when they appear
     # "outdoors" within a regular expression. To be interpreted literally, they
     # must be escaped with a backslash.
-    allSpecial = set("\\[]|().?*+{}")
+    allSpecial = frozenset("\\[]|().?*+{}")
 
     # These are the characters carrying special meanings when they appear
     # INSIDE a character class (delimited by square brackets) within a regular
     # expression. To be interpreted literally, they must be escaped with a
     # backslash. Notice how much smaller this class is than the one above; note
     # also that the hyphen and caret do NOT appear above.
-    classSpecial = set("\\[]^-")
+    classSpecial = frozenset("\\[]^-")
 
     # Shorthand codes for use inside `Charclass`es e.g. [abc\d]
     w = frozenset(
@@ -181,8 +181,7 @@ class Charclass:
         return output
 
     def to_fsm(self, alphabet=None):
-        if alphabet is None:
-            alphabet = self.alphabet()
+        alphabet = self.alphabet() if alphabet is None else frozenset(alphabet)
 
         # 0 is initial, 1 is final
 
@@ -199,7 +198,7 @@ class Charclass:
             }
 
         return Fsm(
-            alphabet=alphabet,
+            alphabet=set(alphabet),
             states={0, 1},
             initial=0,
             finals={1},
@@ -222,7 +221,7 @@ class Charclass:
         return self
 
     def alphabet(self):
-        return {ANYTHING_ELSE} | self.chars
+        return self.chars | {ANYTHING_ELSE}
 
     def empty(self):
         return len(self.chars) == 0 and not self.negated

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -41,10 +41,9 @@ class Charclass:
     def __post_init__(self):
         object.__setattr__(self, "chars", frozenset(self.chars))
         # chars should consist only of chars
-        if ANYTHING_ELSE in self.chars:
-            raise TypeError(
-                f"Can't put {ANYTHING_ELSE!r} in a `Charclass`"
-            )
+        for c in self.chars:
+            if not isinstance(c, str):
+                raise TypeError(f"Can't put {c!r} in a `Charclass`", c)
 
     def __eq__(self, other):
         return isinstance(other, Charclass) \

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -42,7 +42,7 @@ class Charclass:
         object.__setattr__(self, "chars", frozenset(self.chars))
         # chars should consist only of chars
         if ANYTHING_ELSE in self.chars:
-            raise Exception(
+            raise TypeError(
                 f"Can't put {ANYTHING_ELSE!r} in a `Charclass`"
             )
 

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -39,7 +39,7 @@ class Charclass:
     chars: frozenset[str]
     negated: bool
 
-    def __init__(self, chars: Iterable[str], negated: bool = False):
+    def __init__(self, chars: Iterable[str] = (), negated: bool = False):
         chars = frozenset(chars)
         # chars should consist only of chars
         for c in chars:
@@ -267,7 +267,7 @@ SPACECHAR = Charclass("\t\n\v\f\r ")
 
 # This `Charclass` expresses "no possibilities at all"
 # and can never match anything.
-NULLCHARCLASS = Charclass("")
+NULLCHARCLASS = Charclass()
 
 NONWORDCHAR = ~WORDCHAR
 NONDIGITCHAR = ~DIGIT

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -15,6 +15,7 @@ __all__ = (
 )
 
 from dataclasses import dataclass
+from typing import Iterable
 
 from .fsm import ANYTHING_ELSE, Fsm
 
@@ -35,10 +36,10 @@ class Charclass:
     combination functions.
     """
 
-    chars: frozenset[str] | str
+    chars: frozenset[str]
     negated: bool
 
-    def __init__(self, chars: frozenset[str] | str, negated=False):
+    def __init__(self, chars: Iterable[str], negated: bool = False):
         chars = frozenset(chars)
         # chars should consist only of chars
         for c in chars:

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 
 from .fsm import ANYTHING_ELSE, Fsm
 
-# This class currently has broken types due to its "frozenset[str] | str" member.
+# This class currently has broken types due to its frozenset[str] | str member.
 # mypy: allow-untyped-calls
 # mypy: allow-untyped-defs
 # mypy: no-check-untyped-defs

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -24,7 +24,7 @@ from .fsm import ANYTHING_ELSE, Fsm
 # mypy: no-check-untyped-defs
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, init=False)
 class Charclass:
     """
     A `Charclass` is basically a `frozenset` of symbols.
@@ -36,16 +36,19 @@ class Charclass:
     """
 
     chars: frozenset[str] | str
-    negated: bool = False
+    negated: bool
 
-    def __post_init__(self):
-        object.__setattr__(self, "chars", frozenset(self.chars))
+    def __init__(self, chars: frozenset[str] | str, negated=False):
+        chars = frozenset(chars)
         # chars should consist only of chars
-        for c in self.chars:
+        for c in chars:
             if not isinstance(c, str):
                 raise TypeError(f"Can't put {c!r} in a `Charclass`", c)
             if len(c) != 1:
                 raise ValueError("`Charclass` can only contain single chars", c)
+
+        object.__setattr__(self, "chars", chars)
+        object.__setattr__(self, "negated", negated)
 
     def __eq__(self, other):
         return isinstance(other, Charclass) \

--- a/greenery/charclass_test.py
+++ b/greenery/charclass_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from .charclass import (
     DIGIT,
     DOT,
@@ -22,6 +24,17 @@ def test_charclass_equality():
     assert ~Charclass("a") == ~Charclass("a")
     assert ~Charclass("a") != Charclass("a")
     assert Charclass("ab") == Charclass("ba")
+
+
+def test_charclass_ctor():
+    with pytest.raises(Exception):
+        Charclass(frozenset({"a", ANYTHING_ELSE}))  # type: ignore
+
+    assert Charclass("ab") == Charclass(frozenset({"a", "b"}))
+
+    assert not Charclass("ab").negated
+    assert not Charclass("ab", negated=False).negated
+    assert Charclass("ab", negated=True).negated
 
 
 def test_repr():

--- a/greenery/charclass_test.py
+++ b/greenery/charclass_test.py
@@ -15,18 +15,15 @@ from .charclass import (
 )
 from .fsm import ANYTHING_ELSE
 
-# mypy: allow-untyped-calls
-# mypy: allow-untyped-defs
 
-
-def test_charclass_equality():
+def test_charclass_equality() -> None:
     assert Charclass("a") == Charclass("a")
     assert ~Charclass("a") == ~Charclass("a")
     assert ~Charclass("a") != Charclass("a")
     assert Charclass("ab") == Charclass("ba")
 
 
-def test_charclass_ctor():
+def test_charclass_ctor() -> None:
     with pytest.raises(TypeError):
         Charclass(frozenset({"a", ANYTHING_ELSE}))  # type: ignore
 
@@ -40,11 +37,11 @@ def test_charclass_ctor():
     assert Charclass("ab", negated=True).negated
 
 
-def test_repr():
+def test_repr() -> None:
     assert repr(~Charclass("a")) == "~Charclass('a')"
 
 
-def test_charclass_str():
+def test_charclass_str() -> None:
     assert str(WORDCHAR) == "\\w"
     assert str(DIGIT) == "\\d"
     assert str(SPACECHAR) == "\\s"
@@ -82,20 +79,22 @@ def test_charclass_str():
     assert str(~Charclass("^")) == "[^\\^]"
 
 
-def test_charclass_fsm():
+def test_charclass_fsm() -> None:
     # "[^a]"
     nota = (~Charclass("a")).to_fsm()
     assert nota.alphabet == {"a", ANYTHING_ELSE}
-    assert nota.accepts("b")
-    assert nota.accepts(["b"])
-    assert nota.accepts([ANYTHING_ELSE])
+
+    # Fsm methods are not yet typed.
+    assert nota.accepts("b")  # type: ignore
+    assert nota.accepts(["b"])  # type: ignore
+    assert nota.accepts([ANYTHING_ELSE])  # type: ignore
 
 
-def test_charclass_negation():
+def test_charclass_negation() -> None:
     assert ~~Charclass("a") == Charclass("a")
     assert Charclass("a") == ~~Charclass("a")
 
 
-def test_empty():
+def test_empty() -> None:
     assert NULLCHARCLASS.empty()
     assert not DOT.empty()

--- a/greenery/charclass_test.py
+++ b/greenery/charclass_test.py
@@ -30,6 +30,9 @@ def test_charclass_ctor():
     with pytest.raises(TypeError):
         Charclass(frozenset({"a", ANYTHING_ELSE}))  # type: ignore
 
+    with pytest.raises(ValueError):
+        Charclass(frozenset({"a", "aa"}))
+
     assert Charclass("ab") == Charclass(frozenset({"a", "b"}))
 
     assert not Charclass("ab").negated

--- a/greenery/charclass_test.py
+++ b/greenery/charclass_test.py
@@ -27,7 +27,7 @@ def test_charclass_equality():
 
 
 def test_charclass_ctor():
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         Charclass(frozenset({"a", ANYTHING_ELSE}))  # type: ignore
 
     assert Charclass("ab") == Charclass(frozenset({"a", "b"}))

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -191,9 +191,9 @@ def match_charclass(string: str, i):
         pass
 
     # e.g. if seeing "\\t", return "\t"
-    for key in escapes.keys():
+    for ekey in escapes.keys():
         try:
-            return Charclass(key), static(string, i, escapes[key])
+            return Charclass(ekey), static(string, i, escapes[ekey])
         except NoMatch:
             pass
 


### PR DESCRIPTION
This fixes the types of the arguments and attributes of `Charclass`.
The constructor now accepts a general `Iterable[str]` and exposes a `frozenset[str]`.

It also raises slightly more-specific `TypeError`/`ValueError` on invalid entries in the supplied set.

This allows `mypy --strict greenery/charclass{_test}.py` to pass.