### PR TITLE
fsm: immutability and fixed types

### DIFF
--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -79,7 +79,7 @@ alpha_type = Union[str, AnythingElse]
 state_type = Union[int, str, None]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, init=False)
 class Fsm:
     """
     A Finite State Machine or FSM has an alphabet and a set of states. At
@@ -101,7 +101,17 @@ class Fsm:
     states: set[state_type]
     map: dict[state_type, dict[alpha_type, state_type]]
 
-    def __post_init__(self):
+    # noinspection PyShadowingBuiltins
+    # pylint: disable-next=too-many-arguments
+    def __init__(
+        self,
+        alphabet: set[alpha_type],
+        states: set[state_type],
+        initial: state_type,
+        finals: set[state_type],
+        # pylint: disable=redefined-builtin
+        map: dict[state_type, dict[alpha_type, state_type]],
+    ) -> None:
         """
         `alphabet` is an iterable of symbols the FSM can be fed.
         `states` is the set of states for the FSM
@@ -110,11 +120,9 @@ class Fsm:
         `map` may be sparse (i.e. it may omit transitions). In the case of
         omitted transitions, a non-final "oblivion" state is simulated.
         """
-        alphabet = set(self.alphabet)
-        states = set(self.states)
-        initial = self.initial
-        finals = set(self.finals)
-        map = self.map  # pylint: disable=redefined-builtin
+        alphabet = set(alphabet)
+        states = set(states)
+        finals = set(finals)
 
         # Validation. Thanks to immutability, this only needs to be carried out
         # once.

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -105,6 +105,8 @@ class Fsm:
     # pylint: disable-next=too-many-arguments
     def __init__(
         self,
+        /,
+        *,
         alphabet: Iterable[alpha_type],
         states: Iterable[state_type],
         initial: state_type,
@@ -161,7 +163,7 @@ class Fsm:
         object.__setattr__(self, "finals", finals)
         object.__setattr__(self, "map", map)
 
-    def accepts(self, input):
+    def accepts(self, input, /):
         """
         Test whether the present FSM accepts the supplied string (iterable
         of symbols). Equivalently, consider `self` as a possibly-infinite
@@ -182,14 +184,14 @@ class Fsm:
             state = self.map[state][symbol]
         return state in self.finals
 
-    def __contains__(self, string):
+    def __contains__(self, string, /):
         """
         This lets you use the syntax `"a" in fsm1` to see whether the
         string "a" is in the set of strings accepted by `fsm1`.
         """
         return self.accepts(string)
 
-    def reduce(self):
+    def reduce(self, /):
         """
         A result by Brzozowski (1963) shows that a minimal finite state
         machine equivalent to the original can be obtained by reversing the
@@ -197,7 +199,7 @@ class Fsm:
         """
         return self.reversed().reversed()
 
-    def __repr__(self):
+    def __repr__(self, /):
         args = ", ".join([
             f"alphabet={self.alphabet!r}",
             f"states={self.states!r}",
@@ -207,7 +209,7 @@ class Fsm:
         ])
         return f"Fsm({args})"
 
-    def __str__(self):
+    def __str__(self, /):
         rows = []
 
         sorted_alphabet = sorted(self.alphabet)
@@ -316,7 +318,7 @@ class Fsm:
 
         return crawl(alphabet, initial, final, follow).reduce()
 
-    def __add__(self, other):
+    def __add__(self, other, /):
         """
         Concatenate two finite state machines together.
         For example, if self accepts "0*" and other accepts "1+(0|1)",
@@ -326,7 +328,7 @@ class Fsm:
         """
         return self.concatenate(other)
 
-    def star(self):
+    def star(self, /):
         """
         If the present FSM accepts X, returns an FSM accepting X* (i.e. 0
         or more Xes). This is NOT as simple as naively connecting the final
@@ -359,7 +361,7 @@ class Fsm:
 
         return crawl(alphabet, initial, final, follow) | epsilon(alphabet)
 
-    def times(self, multiplier):
+    def times(self, multiplier, /):
         """
         Given an FSM and a multiplier, return the multiplied FSM.
         """
@@ -401,7 +403,7 @@ class Fsm:
 
         return crawl(alphabet, initial, final, follow).reduce()
 
-    def __mul__(self, multiplier):
+    def __mul__(self, multiplier, /):
         """
         Given an FSM and a multiplier, return the multiplied FSM.
         """
@@ -415,7 +417,7 @@ class Fsm:
         """
         return parallel(fsms, any)
 
-    def __or__(self, other):
+    def __or__(self, other, /):
         """
         Alternation.
         Return a finite state machine which accepts any sequence of symbols
@@ -436,7 +438,7 @@ class Fsm:
         """
         return parallel(fsms, all)
 
-    def __and__(self, other):
+    def __and__(self, other, /):
         """
         Treat the FSMs as sets of strings and return the intersection of
         those sets in the form of a new FSM.
@@ -452,14 +454,14 @@ class Fsm:
         """
         return parallel(fsms, lambda accepts: (accepts.count(True) % 2) == 1)
 
-    def __xor__(self, other):
+    def __xor__(self, other, /):
         """
         Symmetric difference. Returns an FSM which recognises only the
         strings recognised by `self` or `other` but not both.
         """
         return self.symmetric_difference(other)
 
-    def everythingbut(self):
+    def everythingbut(self, /):
         """
         Return a finite state machine which will accept any string NOT
         accepted by self, and will not accept any string accepted by self.
@@ -484,7 +486,7 @@ class Fsm:
 
         return crawl(alphabet, initial, final, follow).reduce()
 
-    def reversed(self):
+    def reversed(self, /):
         """
         Return a new FSM such that for every string that self accepts (e.g.
         "beer", the new FSM accepts the reversed string ("reeb").
@@ -517,14 +519,14 @@ class Fsm:
         return crawl(alphabet, initial, final, follow)
         # Do not reduce() the result, since reduce() calls us in turn
 
-    def __reversed__(self):
+    def __reversed__(self, /):
         """
         Return a new FSM such that for every string that self accepts (e.g.
         "beer", the new FSM accepts the reversed string ("reeb").
         """
         return self.reversed()
 
-    def islive(self, state):
+    def islive(self, /, state):
         """A state is "live" if a final state can be reached from it."""
         reachable = [state]
         i = 0
@@ -540,7 +542,7 @@ class Fsm:
             i += 1
         return False
 
-    def empty(self):
+    def empty(self, /):
         """
         An FSM is empty if it recognises no strings. An FSM may be
         arbitrarily complicated and have arbitrarily many final states
@@ -551,7 +553,7 @@ class Fsm:
         """
         return not self.islive(self.initial)
 
-    def strings(self):
+    def strings(self, /):
         """
         Generate strings (lists of symbols) that this FSM accepts. Since
         there may be infinitely many of these we use a generator instead of
@@ -595,13 +597,13 @@ class Fsm:
                         strings.append((nstring, nstate))
             i += 1
 
-    def __iter__(self):
+    def __iter__(self, /):
         """
         This allows you to do `for string in fsm1` as a list comprehension!
         """
         return self.strings()
 
-    def equivalent(self, other):
+    def equivalent(self, other, /):
         """
         Two FSMs are considered equivalent if they recognise the same
         strings. Or, to put it another way, if their symmetric difference
@@ -609,21 +611,21 @@ class Fsm:
         """
         return (self ^ other).empty()
 
-    def __eq__(self, other):
+    def __eq__(self, other, /):
         """
         You can use `fsm1 == fsm2` to determine whether two FSMs recognise
         the same strings.
         """
         return self.equivalent(other)
 
-    def different(self, other):
+    def different(self, other, /):
         """
         Two FSMs are considered different if they have a non-empty
         symmetric difference.
         """
         return not (self ^ other).empty()
 
-    def __ne__(self, other):
+    def __ne__(self, other, /):
         """
         Use `fsm1 != fsm2` to determine whether two FSMs recognise
         different strings.
@@ -640,10 +642,10 @@ class Fsm:
             lambda accepts: accepts[0] and not any(accepts[1:])
         )
 
-    def __sub__(self, other):
+    def __sub__(self, other, /):
         return self.difference(other)
 
-    def cardinality(self):
+    def cardinality(self, /):
         """
         Consider the FSM as a set of strings and return the cardinality of
         that set, or raise an OverflowError if there are infinitely many
@@ -677,21 +679,21 @@ class Fsm:
 
         return get_num_strings(self.initial)
 
-    def __len__(self):
+    def __len__(self, /):
         """
         Consider the FSM as a set of strings and return the cardinality of
         that set, or raise an OverflowError if there are infinitely many
         """
         return self.cardinality()
 
-    def isdisjoint(self, other):
+    def isdisjoint(self, other, /):
         """
         Treat `self` and `other` as sets of strings and see if they are
         disjoint
         """
         return (self & other).empty()
 
-    def issubset(self, other):
+    def issubset(self, other, /):
         """
         Treat `self` and `other` as sets of strings and see if `self` is a
         subset of `other`... `self` recognises no strings which `other`
@@ -699,7 +701,7 @@ class Fsm:
         """
         return (self - other).empty()
 
-    def __le__(self, other):
+    def __le__(self, other, /):
         """
         Treat `self` and `other` as sets of strings and see if `self` is a
         subset of `other`... `self` recognises no strings which `other`
@@ -707,49 +709,49 @@ class Fsm:
         """
         return self.issubset(other)
 
-    def ispropersubset(self, other):
+    def ispropersubset(self, other, /):
         """
         Treat `self` and `other` as sets of strings and see if `self` is a
         proper subset of `other`.
         """
         return self <= other and self != other
 
-    def __lt__(self, other):
+    def __lt__(self, other, /):
         """
         Treat `self` and `other` as sets of strings and see if `self` is a
         strict subset of `other`.
         """
         return self.ispropersubset(other)
 
-    def issuperset(self, other):
+    def issuperset(self, other, /):
         """
         Treat `self` and `other` as sets of strings and see if `self` is a
         superset of `other`.
         """
         return (other - self).empty()
 
-    def __ge__(self, other):
+    def __ge__(self, other, /):
         """
         Treat `self` and `other` as sets of strings and see if `self` is a
         superset of `other`.
         """
         return self.issuperset(other)
 
-    def ispropersuperset(self, other):
+    def ispropersuperset(self, other, /):
         """
         Treat `self` and `other` as sets of strings and see if `self` is a
         proper superset of `other`.
         """
         return self >= other and self != other
 
-    def __gt__(self, other):
+    def __gt__(self, other, /):
         """
         Treat `self` and `other` as sets of strings and see if `self` is a
         strict superset of `other`.
         """
         return self.ispropersuperset(other)
 
-    def copy(self):
+    def copy(self, /):
         """
         For completeness only, since `set.copy()` and `frozenset.copy()` exist.
         FSM objects are immutable; like `frozenset`, this just returns `self`.
@@ -758,7 +760,7 @@ class Fsm:
 
     __copy__ = copy
 
-    def derive(self, input):
+    def derive(self, input, /):
         """
         Compute the Brzozowski derivative of this FSM with respect to the
         input string of symbols.
@@ -828,7 +830,7 @@ def epsilon(alphabet):
     )
 
 
-def parallel(fsms, test):
+def parallel(fsms, test, /):
     """
     Crawl several FSMs in parallel, mapping the states of a larger
     meta-FSM. To determine whether a state in the larger FSM is final, pass

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -110,41 +110,48 @@ class Fsm:
         `map` may be sparse (i.e. it may omit transitions). In the case of
         omitted transitions, a non-final "oblivion" state is simulated.
         """
+        alphabet = set(self.alphabet)
+        states = set(self.states)
+        initial = self.initial
+        finals = set(self.finals)
+        map = self.map  # pylint: disable=redefined-builtin
 
         # Validation. Thanks to immutability, this only needs to be carried out
         # once.
-        if self.initial not in self.states:
+        if initial not in states:
             raise Exception(
-                f"Initial state {self.initial!r}"
-                f" must be one of {self.states!r}"
+                f"Initial state {initial!r}"
+                f" must be one of {states!r}"
             )
-        if not self.finals.issubset(self.states):
+        if not finals.issubset(states):
             raise Exception(
-                f"Final states {self.finals!r}"
-                f" must be a subset of {self.states!r}"
+                f"Final states {finals!r}"
+                f" must be a subset of {states!r}"
             )
-        for state, _state_trans in self.map.items():
-            if state not in self.states:
+        for state, _state_trans in map.items():
+            if state not in states:
                 raise Exception(f"Transition from unknown state {state!r}")
-            for symbol in self.map[state]:
-                if symbol not in self.alphabet:
+            for symbol in map[state]:
+                if symbol not in alphabet:
                     raise Exception(
                         f"Invalid symbol {symbol!r}"
                         f" in transition from {state!r}"
-                        f" to {self.map[state][symbol]!r}"
+                        f" to {map[state][symbol]!r}"
                     )
-                if not self.map[state][symbol] in self.states:
+                if not map[state][symbol] in states:
                     raise Exception(
                         f"Transition for state {state!r}"
                         f" and symbol {symbol!r}"
-                        f" leads to {self.map[state][symbol]!r},"
+                        f" leads to {map[state][symbol]!r},"
                         " which is not a state"
                     )
 
         # Initialise the hard way due to immutability.
-        object.__setattr__(self, "alphabet", set(self.alphabet))
-        object.__setattr__(self, "states", set(self.states))
-        object.__setattr__(self, "finals", set(self.finals))
+        object.__setattr__(self, "alphabet", alphabet)
+        object.__setattr__(self, "states", states)
+        object.__setattr__(self, "initial", initial)
+        object.__setattr__(self, "finals", finals)
+        object.__setattr__(self, "map", map)
 
     def accepts(self, input):
         """

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -95,10 +95,10 @@ class Fsm:
     The majority of these methods are available using operator overloads.
     """
 
-    initial: state_type
-    finals: set[state_type]
     alphabet: set[alpha_type]
     states: set[state_type]
+    initial: state_type
+    finals: set[state_type]
     map: dict[state_type, dict[alpha_type, state_type]]
 
     # noinspection PyShadowingBuiltins

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -756,6 +756,8 @@ class Fsm:
         """
         return self
 
+    __copy__ = copy
+
     def derive(self, input):
         """
         Compute the Brzozowski derivative of this FSM with respect to the

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -16,7 +16,7 @@ __all__ = (
 from dataclasses import dataclass
 from enum import Enum, auto
 from functools import total_ordering
-from typing import Any, Mapping, Union
+from typing import Any, Iterable, Mapping, Union
 
 # mypy: allow-incomplete-defs
 # mypy: allow-untyped-calls
@@ -105,12 +105,12 @@ class Fsm:
     # pylint: disable-next=too-many-arguments
     def __init__(
         self,
-        alphabet: set[alpha_type],
-        states: set[state_type],
+        alphabet: Iterable[alpha_type],
+        states: Iterable[state_type],
         initial: state_type,
-        finals: set[state_type],
+        finals: Iterable[state_type],
         # pylint: disable=redefined-builtin
-        map: dict[state_type, dict[alpha_type, state_type]],
+        map: Mapping[state_type, Mapping[alpha_type, state_type]],
     ) -> None:
         """
         `alphabet` is an iterable of symbols the FSM can be fed.
@@ -120,9 +120,9 @@ class Fsm:
         `map` may be sparse (i.e. it may omit transitions). In the case of
         omitted transitions, a non-final "oblivion" state is simulated.
         """
-        alphabet = set(alphabet)
-        states = set(states)
-        finals = set(finals)
+        alphabet = frozenset(alphabet)
+        states = frozenset(states)
+        finals = frozenset(finals)
 
         # Validation. Thanks to immutability, this only needs to be carried out
         # once.
@@ -155,10 +155,10 @@ class Fsm:
                     )
 
         # Initialise the hard way due to immutability.
-        object.__setattr__(self, "alphabet", frozenset(alphabet))
-        object.__setattr__(self, "states", frozenset(states))
+        object.__setattr__(self, "alphabet", alphabet)
+        object.__setattr__(self, "states", states)
         object.__setattr__(self, "initial", initial)
-        object.__setattr__(self, "finals", frozenset(finals))
+        object.__setattr__(self, "finals", finals)
         object.__setattr__(self, "map", map)
 
     def accepts(self, input):
@@ -811,7 +811,7 @@ def null(alphabet):
         alphabet=alphabet,
         states={0},
         initial=0,
-        finals=set(),
+        finals=(),
         map={
             0: dict([(symbol, 0) for symbol in alphabet]),
         },

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -616,6 +616,8 @@ class Fsm:
         You can use `fsm1 == fsm2` to determine whether two FSMs recognise
         the same strings.
         """
+        if not isinstance(other, Fsm):
+            return NotImplemented
         return self.equivalent(other)
 
     def different(self, other, /):
@@ -630,7 +632,7 @@ class Fsm:
         Use `fsm1 != fsm2` to determine whether two FSMs recognise
         different strings.
         """
-        return self.different(other)
+        return not self == other
 
     def difference(*fsms):
         """

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -16,12 +16,16 @@ __all__ = (
 from dataclasses import dataclass
 from enum import Enum, auto
 from functools import total_ordering
-from typing import Any, Iterable, Mapping, Union
-
-# mypy: allow-incomplete-defs
-# mypy: allow-untyped-calls
-# mypy: allow-untyped-defs
-# mypy: no-check-untyped-defs
+from typing import (
+    Any,
+    Callable,
+    Collection,
+    Iterable,
+    Iterator,
+    Mapping,
+    TypeVar,
+    Union,
+)
 
 
 @total_ordering
@@ -77,6 +81,9 @@ alpha_type = Union[str, AnythingElse]
 
 
 state_type = Union[int, str, None]
+
+M = TypeVar("M")
+"""Meta-state type for crawl(). Can be anything."""
 
 
 @dataclass(frozen=True, init=False)
@@ -163,7 +170,7 @@ class Fsm:
         object.__setattr__(self, "finals", finals)
         object.__setattr__(self, "map", map)
 
-    def accepts(self, input, /):
+    def accepts(self, input: Iterable[alpha_type], /) -> bool:
         """
         Test whether the present FSM accepts the supplied string (iterable
         of symbols). Equivalently, consider `self` as a possibly-infinite
@@ -184,14 +191,14 @@ class Fsm:
             state = self.map[state][symbol]
         return state in self.finals
 
-    def __contains__(self, string, /):
+    def __contains__(self, string: Iterable[alpha_type], /) -> bool:
         """
         This lets you use the syntax `"a" in fsm1` to see whether the
         string "a" is in the set of strings accepted by `fsm1`.
         """
         return self.accepts(string)
 
-    def reduce(self, /):
+    def reduce(self, /) -> Fsm:
         """
         A result by Brzozowski (1963) shows that a minimal finite state
         machine equivalent to the original can be obtained by reversing the
@@ -199,7 +206,7 @@ class Fsm:
         """
         return self.reversed().reversed()
 
-    def __repr__(self, /):
+    def __repr__(self, /) -> str:
         args = ", ".join([
             f"alphabet={self.alphabet!r}",
             f"states={self.states!r}",
@@ -209,7 +216,7 @@ class Fsm:
         ])
         return f"Fsm({args})"
 
-    def __str__(self, /):
+    def __str__(self, /) -> str:
         rows = []
 
         sorted_alphabet = sorted(self.alphabet)
@@ -255,13 +262,13 @@ class Fsm:
 
         return "".join("".join(row) + "\n" for row in rows)
 
-    def concatenate(*fsms):
+    def concatenate(*fsms: Fsm) -> Fsm:
         """
         Concatenate arbitrarily many finite state machines together.
         """
         alphabet = set().union(*[fsm.alphabet for fsm in fsms])
 
-        def connect_all(i, substate):
+        def connect_all(i: int, substate: state_type) -> Iterable[tuple[int, state_type]]:
             """
             Take a state in the numbered FSM and return a set containing
             it, plus (if it's final) the first state from the next FSM,
@@ -279,26 +286,29 @@ class Fsm:
         # We start at the start of the first FSM. If this state is final in the
         # first FSM, then we are also at the start of the second FSM. And so
         # on.
-        initial = set()
+        initial_: set[tuple[int, state_type]] = set()
         if len(fsms) > 0:
-            initial.update(connect_all(0, fsms[0].initial))
-        initial = frozenset(initial)
+            initial_.update(connect_all(0, fsms[0].initial))
+        initial: frozenset[tuple[int, state_type]] = frozenset(initial_)
 
-        def final(state):
+        def final(state: frozenset[tuple[int, state_type]]) -> bool:
             """If you're in a final state of the final FSM, it's final"""
             for (i, substate) in state:
                 if i == len(fsms) - 1 and substate in fsms[i].finals:
                     return True
             return False
 
-        def follow(current, symbol):
+        def follow(
+            current: frozenset[tuple[int, state_type]],
+            symbol: alpha_type,
+        ) -> frozenset[tuple[int, state_type]]:
             """
             Follow the collection of states through all FSMs at once,
             jumping to the next FSM if we reach the end of the current one
             TODO: improve all follow() implementations to allow for dead
             metastates?
             """
-            next = set()
+            next: set[tuple[int, state_type]] = set()
             for (i, substate) in current:
                 fsm = fsms[i]
                 if substate in fsm.map:
@@ -318,7 +328,7 @@ class Fsm:
 
         return crawl(alphabet, initial, final, follow).reduce()
 
-    def __add__(self, other, /):
+    def __add__(self, other: Fsm, /) -> Fsm:
         """
         Concatenate two finite state machines together.
         For example, if self accepts "0*" and other accepts "1+(0|1)",
@@ -328,7 +338,7 @@ class Fsm:
         """
         return self.concatenate(other)
 
-    def star(self, /):
+    def star(self, /) -> Fsm:
         """
         If the present FSM accepts X, returns an FSM accepting X* (i.e. 0
         or more Xes). This is NOT as simple as naively connecting the final
@@ -336,10 +346,14 @@ class Fsm:
         """
         alphabet = self.alphabet
 
-        initial = {self.initial}
+        initial: Collection[state_type] = {self.initial}
 
-        def follow(state, symbol):
+        def follow(
+            state: Collection[state_type],
+            symbol: alpha_type,
+        ) -> Collection[state_type]:
             next = set()
+
             for substate in state:
                 if substate in self.map and symbol in self.map[substate]:
                     next.add(self.map[substate][symbol])
@@ -356,12 +370,12 @@ class Fsm:
 
             return frozenset(next)
 
-        def final(state):
+        def final(state: Collection[state_type]) -> bool:
             return any(substate in self.finals for substate in state)
 
         return crawl(alphabet, initial, final, follow) | epsilon(alphabet)
 
-    def times(self, multiplier, /):
+    def times(self, multiplier: int, /) -> Fsm:
         """
         Given an FSM and a multiplier, return the multiplied FSM.
         """
@@ -371,9 +385,9 @@ class Fsm:
         alphabet = self.alphabet
 
         # metastate is a set of iterations+states
-        initial = {(self.initial, 0)}
+        initial: Collection[tuple[state_type, int]] = {(self.initial, 0)}
 
-        def final(state):
+        def final(state: Collection[tuple[state_type, int]]) -> bool:
             """
             If the initial state is final then multiplying doesn't alter
             that
@@ -387,7 +401,10 @@ class Fsm:
                     return True
             return False
 
-        def follow(current, symbol):
+        def follow(
+            current: Collection[tuple[state_type, int]],
+            symbol: alpha_type,
+        ) -> Collection[tuple[state_type, int]]:
             next = []
             for (substate, iteration) in current:
                 if iteration < multiplier \
@@ -403,13 +420,13 @@ class Fsm:
 
         return crawl(alphabet, initial, final, follow).reduce()
 
-    def __mul__(self, multiplier, /):
+    def __mul__(self, multiplier: int, /) -> Fsm:
         """
         Given an FSM and a multiplier, return the multiplied FSM.
         """
         return self.times(multiplier)
 
-    def union(*fsms):
+    def union(*fsms: Fsm) -> Fsm:
         """
         Treat `fsms` as a collection of arbitrary FSMs and return the union
         FSM. Can be used as `fsm1.union(fsm2, ...)` or
@@ -417,7 +434,7 @@ class Fsm:
         """
         return parallel(fsms, any)
 
-    def __or__(self, other, /):
+    def __or__(self, other: Fsm, /) -> Fsm:
         """
         Alternation.
         Return a finite state machine which accepts any sequence of symbols
@@ -427,7 +444,7 @@ class Fsm:
         """
         return self.union(other)
 
-    def intersection(*fsms):
+    def intersection(*fsms: Fsm) -> Fsm:
         """
         Intersection.
         Take FSMs and AND them together. That is, return an FSM which
@@ -438,14 +455,14 @@ class Fsm:
         """
         return parallel(fsms, all)
 
-    def __and__(self, other, /):
+    def __and__(self, other: Fsm, /) -> Fsm:
         """
         Treat the FSMs as sets of strings and return the intersection of
         those sets in the form of a new FSM.
         """
         return self.intersection(other)
 
-    def symmetric_difference(*fsms):
+    def symmetric_difference(*fsms: Fsm) -> Fsm:
         """
         Treat `fsms` as a collection of sets of strings and compute the
         symmetric difference of them all. The python set method only allows
@@ -454,14 +471,14 @@ class Fsm:
         """
         return parallel(fsms, lambda accepts: (accepts.count(True) % 2) == 1)
 
-    def __xor__(self, other, /):
+    def __xor__(self, other: Fsm, /) -> Fsm:
         """
         Symmetric difference. Returns an FSM which recognises only the
         strings recognised by `self` or `other` but not both.
         """
         return self.symmetric_difference(other)
 
-    def everythingbut(self, /):
+    def everythingbut(self, /) -> Fsm:
         """
         Return a finite state machine which will accept any string NOT
         accepted by self, and will not accept any string accepted by self.
@@ -470,9 +487,12 @@ class Fsm:
         """
         alphabet = self.alphabet
 
-        initial = {0: self.initial}
+        initial: Mapping[int, state_type] = {0: self.initial}
 
-        def follow(current, symbol):
+        def follow(
+            current: Mapping[int, state_type],
+            symbol: alpha_type,
+        ) -> Mapping[int, state_type]:
             next = {}
             if 0 in current \
                and current[0] in self.map \
@@ -481,12 +501,12 @@ class Fsm:
             return next
 
         # state is final unless the original was
-        def final(state):
+        def final(state: Mapping[int, state_type]) -> bool:
             return not (0 in state and state[0] in self.finals)
 
         return crawl(alphabet, initial, final, follow).reduce()
 
-    def reversed(self, /):
+    def reversed(self, /) -> Fsm:
         """
         Return a new FSM such that for every string that self accepts (e.g.
         "beer", the new FSM accepts the reversed string ("reeb").
@@ -500,7 +520,10 @@ class Fsm:
 
         # Find every possible way to reach the current state-set
         # using this symbol.
-        def follow(current, symbol):
+        def follow(
+            current: frozenset[state_type],
+            symbol: alpha_type,
+        ) -> frozenset[state_type]:
             next = frozenset([
                 prev
                 for prev in self.map
@@ -512,21 +535,21 @@ class Fsm:
             return next
 
         # A state-set is final if the initial state is in it.
-        def final(state):
+        def final(state: frozenset[state_type]) -> bool:
             return self.initial in state
 
         # Man, crawl() is the best!
         return crawl(alphabet, initial, final, follow)
         # Do not reduce() the result, since reduce() calls us in turn
 
-    def __reversed__(self, /):
+    def __reversed__(self, /) -> Fsm:
         """
         Return a new FSM such that for every string that self accepts (e.g.
         "beer", the new FSM accepts the reversed string ("reeb").
         """
         return self.reversed()
 
-    def islive(self, /, state):
+    def islive(self, /, state: state_type) -> bool:
         """A state is "live" if a final state can be reached from it."""
         reachable = [state]
         i = 0
@@ -542,7 +565,7 @@ class Fsm:
             i += 1
         return False
 
-    def empty(self, /):
+    def empty(self, /) -> bool:
         """
         An FSM is empty if it recognises no strings. An FSM may be
         arbitrarily complicated and have arbitrarily many final states
@@ -553,7 +576,7 @@ class Fsm:
         """
         return not self.islive(self.initial)
 
-    def strings(self, /):
+    def strings(self, /) -> Iterator[list[alpha_type]]:
         """
         Generate strings (lists of symbols) that this FSM accepts. Since
         there may be infinitely many of these we use a generator instead of
@@ -573,11 +596,11 @@ class Fsm:
         # the state that this input string leads to. This means we don't have
         # to run the state machine from the very beginning every time we want
         # to check a new string.
-        strings = []
+        strings: list[tuple[list[alpha_type], state_type]] = []
 
         # Initial entry (or possibly not, in which case this is a short one)
-        cstate = self.initial
-        cstring = []
+        cstate: state_type = self.initial
+        cstring: list[alpha_type] = []
         if cstate in livestates:
             if cstate in self.finals:
                 yield cstring
@@ -597,13 +620,13 @@ class Fsm:
                         strings.append((nstring, nstate))
             i += 1
 
-    def __iter__(self, /):
+    def __iter__(self, /) -> Iterator[list[alpha_type]]:
         """
         This allows you to do `for string in fsm1` as a list comprehension!
         """
         return self.strings()
 
-    def equivalent(self, other, /):
+    def equivalent(self, other: Fsm, /) -> bool:
         """
         Two FSMs are considered equivalent if they recognise the same
         strings. Or, to put it another way, if their symmetric difference
@@ -611,7 +634,7 @@ class Fsm:
         """
         return (self ^ other).empty()
 
-    def __eq__(self, other, /):
+    def __eq__(self, other: object, /) -> bool:
         """
         You can use `fsm1 == fsm2` to determine whether two FSMs recognise
         the same strings.
@@ -620,21 +643,21 @@ class Fsm:
             return NotImplemented
         return self.equivalent(other)
 
-    def different(self, other, /):
+    def different(self, other: Fsm, /) -> bool:
         """
         Two FSMs are considered different if they have a non-empty
         symmetric difference.
         """
         return not (self ^ other).empty()
 
-    def __ne__(self, other, /):
+    def __ne__(self, other: object, /) -> bool:
         """
         Use `fsm1 != fsm2` to determine whether two FSMs recognise
         different strings.
         """
         return not self == other
 
-    def difference(*fsms):
+    def difference(*fsms: Fsm) -> Fsm:
         """
         Difference. Returns an FSM which recognises only the strings
         recognised by the first FSM in the list, but none of the others.
@@ -644,17 +667,17 @@ class Fsm:
             lambda accepts: accepts[0] and not any(accepts[1:])
         )
 
-    def __sub__(self, other, /):
+    def __sub__(self, other: Fsm, /) -> Fsm:
         return self.difference(other)
 
-    def cardinality(self, /):
+    def cardinality(self, /) -> int:
         """
         Consider the FSM as a set of strings and return the cardinality of
         that set, or raise an OverflowError if there are infinitely many
         """
-        num_strings = {}
+        num_strings: dict[state_type, int | None] = {}
 
-        def get_num_strings(state):
+        def get_num_strings(state: state_type) -> int:
             # Many FSMs have at least one oblivion state
             if self.islive(state):
                 if state in num_strings:
@@ -662,7 +685,7 @@ class Fsm:
                         # Recursion! There are infinitely many strings
                         # recognised
                         raise OverflowError(state)
-                    return num_strings[state]
+                    return num_strings[state]  # type: ignore
                 num_strings[state] = None  # i.e. "computing..."
 
                 n = 0
@@ -677,25 +700,25 @@ class Fsm:
                 # Dead state
                 num_strings[state] = 0
 
-            return num_strings[state]
+            return num_strings[state]  # type: ignore
 
         return get_num_strings(self.initial)
 
-    def __len__(self, /):
+    def __len__(self, /) -> int:
         """
         Consider the FSM as a set of strings and return the cardinality of
         that set, or raise an OverflowError if there are infinitely many
         """
         return self.cardinality()
 
-    def isdisjoint(self, other, /):
+    def isdisjoint(self, other: Fsm, /) -> bool:
         """
         Treat `self` and `other` as sets of strings and see if they are
         disjoint
         """
         return (self & other).empty()
 
-    def issubset(self, other, /):
+    def issubset(self, other: Fsm, /) -> bool:
         """
         Treat `self` and `other` as sets of strings and see if `self` is a
         subset of `other`... `self` recognises no strings which `other`
@@ -703,7 +726,7 @@ class Fsm:
         """
         return (self - other).empty()
 
-    def __le__(self, other, /):
+    def __le__(self, other: Fsm, /) -> bool:
         """
         Treat `self` and `other` as sets of strings and see if `self` is a
         subset of `other`... `self` recognises no strings which `other`
@@ -711,49 +734,49 @@ class Fsm:
         """
         return self.issubset(other)
 
-    def ispropersubset(self, other, /):
+    def ispropersubset(self, other: Fsm, /) -> bool:
         """
         Treat `self` and `other` as sets of strings and see if `self` is a
         proper subset of `other`.
         """
         return self <= other and self != other
 
-    def __lt__(self, other, /):
+    def __lt__(self, other: Fsm, /) -> bool:
         """
         Treat `self` and `other` as sets of strings and see if `self` is a
         strict subset of `other`.
         """
         return self.ispropersubset(other)
 
-    def issuperset(self, other, /):
+    def issuperset(self, other: Fsm, /) -> bool:
         """
         Treat `self` and `other` as sets of strings and see if `self` is a
         superset of `other`.
         """
         return (other - self).empty()
 
-    def __ge__(self, other, /):
+    def __ge__(self, other: Fsm, /) -> bool:
         """
         Treat `self` and `other` as sets of strings and see if `self` is a
         superset of `other`.
         """
         return self.issuperset(other)
 
-    def ispropersuperset(self, other, /):
+    def ispropersuperset(self, other: Fsm, /) -> bool:
         """
         Treat `self` and `other` as sets of strings and see if `self` is a
         proper superset of `other`.
         """
         return self >= other and self != other
 
-    def __gt__(self, other, /):
+    def __gt__(self, other: Fsm, /) -> bool:
         """
         Treat `self` and `other` as sets of strings and see if `self` is a
         strict superset of `other`.
         """
         return self.ispropersuperset(other)
 
-    def copy(self, /):
+    def copy(self, /) -> Fsm:
         """
         For completeness only, since `set.copy()` and `frozenset.copy()` exist.
         FSM objects are immutable; like `frozenset`, this just returns `self`.
@@ -762,7 +785,7 @@ class Fsm:
 
     __copy__ = copy
 
-    def derive(self, input, /):
+    def derive(self, input: Iterable[alpha_type], /) -> Fsm:
         """
         Compute the Brzozowski derivative of this FSM with respect to the
         input string of symbols.
@@ -801,7 +824,7 @@ class Fsm:
             return null(self.alphabet)
 
 
-def null(alphabet):
+def null(alphabet: Iterable[alpha_type]) -> Fsm:
     """
     An FSM accepting nothing (not even the empty string). This is
     demonstrates that this is possible, and is also extremely useful
@@ -818,7 +841,7 @@ def null(alphabet):
     )
 
 
-def epsilon(alphabet):
+def epsilon(alphabet: Iterable[alpha_type]) -> Fsm:
     """
     Return an FSM matching an empty string, "", only.
     This is very useful in many situations
@@ -832,7 +855,11 @@ def epsilon(alphabet):
     )
 
 
-def parallel(fsms, test, /):
+def parallel(
+    fsms: tuple[Fsm, ...],
+    test: Callable[[list[bool]], bool],
+    /,
+) -> Fsm:
     """
     Crawl several FSMs in parallel, mapping the states of a larger
     meta-FSM. To determine whether a state in the larger FSM is final, pass
@@ -840,13 +867,18 @@ def parallel(fsms, test, /):
     """
     alphabet = set().union(*[fsm.alphabet for fsm in fsms])
 
-    initial = dict([(i, fsm.initial) for (i, fsm) in enumerate(fsms)])
+    initial: Mapping[int, state_type] = dict(
+        [(i, fsm.initial) for (i, fsm) in enumerate(fsms)])
 
     # dedicated function accepts a "superset" and returns the next "superset"
     # obtained by following this transition in the new FSM
-    def follow(current, symbol):
+    def follow(
+        current: Mapping[int, state_type],
+        symbol: alpha_type,
+    ) -> Mapping[int, state_type]:
         next = {}
         for i in range(len(fsms)):
+            actual_symbol: alpha_type
             if symbol not in fsms[i].alphabet \
                and ANYTHING_ELSE in fsms[i].alphabet:
                 actual_symbol = ANYTHING_ELSE
@@ -862,7 +894,7 @@ def parallel(fsms, test, /):
 
     # Determine the "is final?" condition of each substate, then pass it to the
     # test to determine finality of the overall FSM.
-    def final(state):
+    def final(state: Mapping[int, state_type]) -> bool:
         accepts = [
             i in state and state[i] in fsm.finals
             for (i, fsm) in enumerate(fsms)
@@ -872,7 +904,12 @@ def parallel(fsms, test, /):
     return crawl(alphabet, initial, final, follow).reduce()
 
 
-def crawl(alphabet, initial, final, follow):
+def crawl(
+    alphabet: Iterable[alpha_type],
+    initial: M,
+    final: Callable[[M], bool],
+    follow: Callable[[M, alpha_type], M],
+) -> Fsm:
     """
     Given the above conditions and instructions, crawl a new unknown FSM,
     mapping its states, final states and transitions. Return the new FSM.
@@ -880,9 +917,9 @@ def crawl(alphabet, initial, final, follow):
     forever if you supply an evil version of follow().
     """
 
-    states = [initial]
-    finals = set()
-    map = {}
+    states: list[M] = [initial]
+    finals: set[state_type] = set()
+    map: dict[state_type, dict[alpha_type, state_type]] = {}
 
     # iterate over a growing list
     i = 0

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -751,16 +751,10 @@ class Fsm:
 
     def copy(self):
         """
-        For completeness only, since `set.copy()` also exists. FSM objects
-        are immutable, so I can see only very odd reasons to need this.
+        For completeness only, since `set.copy()` and `frozenset.copy()` exist.
+        FSM objects are immutable; like `frozenset`, this just returns `self`.
         """
-        return Fsm(
-            alphabet=self.alphabet,
-            states=self.states,
-            initial=self.initial,
-            finals=self.finals,
-            map=self.map,
-        )
+        return self
 
     def derive(self, input):
         """

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -16,7 +16,7 @@ __all__ = (
 from dataclasses import dataclass
 from enum import Enum, auto
 from functools import total_ordering
-from typing import Any, Union
+from typing import Any, Mapping, Union
 
 # mypy: allow-incomplete-defs
 # mypy: allow-untyped-calls
@@ -95,11 +95,11 @@ class Fsm:
     The majority of these methods are available using operator overloads.
     """
 
-    alphabet: set[alpha_type]
-    states: set[state_type]
+    alphabet: frozenset[alpha_type]
+    states: frozenset[state_type]
     initial: state_type
-    finals: set[state_type]
-    map: dict[state_type, dict[alpha_type, state_type]]
+    finals: frozenset[state_type]
+    map: Mapping[state_type, Mapping[alpha_type, state_type]]
 
     # noinspection PyShadowingBuiltins
     # pylint: disable-next=too-many-arguments
@@ -155,10 +155,10 @@ class Fsm:
                     )
 
         # Initialise the hard way due to immutability.
-        object.__setattr__(self, "alphabet", alphabet)
-        object.__setattr__(self, "states", states)
+        object.__setattr__(self, "alphabet", frozenset(alphabet))
+        object.__setattr__(self, "states", frozenset(states))
         object.__setattr__(self, "initial", initial)
-        object.__setattr__(self, "finals", finals)
+        object.__setattr__(self, "finals", frozenset(finals))
         object.__setattr__(self, "map", map)
 
     def accepts(self, input):

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -7,12 +7,12 @@ import pytest
 
 from .fsm import ANYTHING_ELSE, AnythingElse, Fsm, epsilon, null
 
-# mypy: allow-untyped-calls
-# mypy: allow-untyped-defs
-# mypy: no-check-untyped-defs
+FixtureA = Fsm
+
+FixtureB = Fsm
 
 
-def test_addbug():
+def test_addbug() -> None:
     # Odd bug with Fsm.__add__(), exposed by "[bc]*c"
     int5A = Fsm(
         alphabet={"a", "b", "c", ANYTHING_ELSE},
@@ -44,14 +44,14 @@ def test_addbug():
     # assert int5C.initial == 0
 
 
-def test_builtins():
+def test_builtins() -> None:
     assert not null("a").accepts("a")
     assert epsilon("a").accepts("")
     assert not epsilon("a").accepts("a")
 
 
 @pytest.fixture
-def a():
+def a() -> FixtureA:
     a = Fsm(
         alphabet={"a", "b"},
         states={0, 1, "ob"},
@@ -66,14 +66,14 @@ def a():
     return a
 
 
-def test_a(a):
+def test_a(a: FixtureA) -> None:
     assert not a.accepts("")
     assert a.accepts("a")
     assert not a.accepts("b")
 
 
 @pytest.fixture
-def b():
+def b() -> FixtureB:
     b = Fsm(
         alphabet={"a", "b"},
         states={0, 1, "ob"},
@@ -88,13 +88,13 @@ def b():
     return b
 
 
-def test_b(b):
+def test_b(b: FixtureB) -> None:
     assert not b.accepts("")
     assert not b.accepts("a")
     assert b.accepts("b")
 
 
-def test_concatenation_aa(a):
+def test_concatenation_aa(a: FixtureA) -> None:
     concAA = a + a
     assert not concAA.accepts("")
     assert not concAA.accepts("a")
@@ -108,7 +108,7 @@ def test_concatenation_aa(a):
     assert not concAA.accepts("aaa")
 
 
-def test_concatenation_ab(a, b):
+def test_concatenation_ab(a: FixtureA, b: FixtureB) -> None:
     concAB = a + b
     assert not concAB.accepts("")
     assert not concAB.accepts("a")
@@ -119,13 +119,13 @@ def test_concatenation_ab(a, b):
     assert not concAB.accepts("bb")
 
 
-def test_alternation_a(a):
+def test_alternation_a(a: FixtureA) -> None:
     altA = a | null({"a", "b"})
     assert not altA.accepts("")
     assert altA.accepts("a")
 
 
-def test_alternation_ab(a, b):
+def test_alternation_ab(a: FixtureA, b: FixtureB) -> None:
     altAB = a | b
     assert not altAB.accepts("")
     assert altAB.accepts("a")
@@ -136,7 +136,7 @@ def test_alternation_ab(a, b):
     assert not altAB.accepts("bb")
 
 
-def test_star(a):
+def test_star(a: FixtureA) -> None:
     starA = a.star()
     assert starA.accepts("")
     assert starA.accepts("a")
@@ -144,20 +144,20 @@ def test_star(a):
     assert starA.accepts("aaaaaaaaa")
 
 
-def test_multiply_0(a):
+def test_multiply_0(a: FixtureA) -> None:
     zeroA = a * 0
     assert zeroA.accepts("")
     assert not zeroA.accepts("a")
 
 
-def test_multiply_1(a):
+def test_multiply_1(a: FixtureA) -> None:
     oneA = a * 1
     assert not oneA.accepts("")
     assert oneA.accepts("a")
     assert not oneA.accepts("aa")
 
 
-def test_multiply_2(a):
+def test_multiply_2(a: FixtureA) -> None:
     twoA = a * 2
     assert not twoA.accepts("")
     assert not twoA.accepts("a")
@@ -165,14 +165,14 @@ def test_multiply_2(a):
     assert not twoA.accepts("aaa")
 
 
-def test_multiply_7(a):
+def test_multiply_7(a: FixtureA) -> None:
     sevenA = a * 7
     assert not sevenA.accepts("aaaaaa")
     assert sevenA.accepts("aaaaaaa")
     assert not sevenA.accepts("aaaaaaaa")
 
 
-def test_optional_mul(a, b):
+def test_optional_mul(a: FixtureA, b: FixtureB) -> None:
     unit = a + b
     # accepts "ab"
 
@@ -197,14 +197,14 @@ def test_optional_mul(a, b):
     assert optional.accepts(["a", "b", "a", "b"])
 
 
-def test_intersection_ab(a, b):
+def test_intersection_ab(a: FixtureA, b: FixtureB) -> None:
     intAB = a & b
     assert not intAB.accepts("")
     assert not intAB.accepts("a")
     assert not intAB.accepts("b")
 
 
-def test_negation(a):
+def test_negation(a: FixtureA) -> None:
     everythingbutA = a.everythingbut()
     assert everythingbutA.accepts("")
     assert not everythingbutA.accepts("a")
@@ -213,7 +213,7 @@ def test_negation(a):
     assert everythingbutA.accepts("ab")
 
 
-def test_crawl_reduction():
+def test_crawl_reduction() -> None:
     # this is "0*1" in heavy disguise. crawl should resolve this duplication
     # Notice how states 2 and 3 behave identically. When resolved together,
     # states 1 and 2&3 also behave identically, so they, too should be resolved
@@ -235,7 +235,7 @@ def test_crawl_reduction():
     assert len(merged.states) == 2
 
 
-def test_bug_28():
+def test_bug_28() -> None:
     # This is (ab*)* and it caused some defects.
     abstar = Fsm(
         alphabet={"a", "b"},
@@ -258,7 +258,7 @@ def test_bug_28():
     assert not abstar.star().accepts("bb")
 
 
-def test_star_advanced():
+def test_star_advanced() -> None:
     # This is (a*ba)*. Naively connecting the final states to the initial state
     # gives the incorrect result here.
     starred = Fsm(
@@ -285,9 +285,9 @@ def test_star_advanced():
     assert starred.accepts("abababa")
 
 
-def test_reduce():
+def test_reduce() -> None:
     # FSM accepts no strings but has 3 states, needs only 1
-    symbol = ()
+    symbol = "x"
     asdf = Fsm(
         alphabet={symbol},
         states={0, 1, 2},
@@ -303,7 +303,7 @@ def test_reduce():
     assert len(asdf.states) == 1
 
 
-def test_reverse_abc():
+def test_reverse_abc() -> None:
     abc = Fsm(
         alphabet={"a", "b", "c"},
         states={0, 1, 2, 3, None},
@@ -321,7 +321,7 @@ def test_reverse_abc():
     assert cba.accepts("cba")
 
 
-def test_reverse_brzozowski():
+def test_reverse_brzozowski() -> None:
     # This is (a|b)*a(a|b)
     brzozowski = Fsm(
         alphabet={"a", "b"},
@@ -373,12 +373,12 @@ def test_reverse_brzozowski():
     assert next(gen) == ["a", "a", "a", "a"]
 
 
-def test_reverse_epsilon():
+def test_reverse_epsilon() -> None:
     # epsilon reversed is epsilon
     assert epsilon("a").reversed().accepts("")
 
 
-def test_binary_3():
+def test_binary_3() -> None:
     # Binary numbers divisible by 3.
     # Disallows the empty string
     # Allows "0" on its own, but not leading zeroes.
@@ -423,7 +423,7 @@ def test_binary_3():
     assert div3.accepts("1001")
 
 
-def test_invalid_fsms():
+def test_invalid_fsms() -> None:
     # initial state 1 is not a state
     with pytest.raises(Exception, match="Initial state"):
         Fsm(
@@ -479,12 +479,12 @@ def test_invalid_fsms():
         )
 
 
-def test_bad_multiplier(a):
+def test_bad_multiplier(a: FixtureA) -> None:
     with pytest.raises(Exception, match="Can't multiply"):
         a * -1
 
 
-def test_anything_else_acceptance():
+def test_anything_else_acceptance() -> None:
     a = Fsm(
         alphabet={"a", "b", "c", ANYTHING_ELSE},
         states={1},
@@ -497,7 +497,7 @@ def test_anything_else_acceptance():
     assert a.accepts("d")
 
 
-def test_difference(a, b):
+def test_difference(a: FixtureA, b: FixtureB) -> None:
     aorb = Fsm(
         alphabet={"a", "b"},
         states={0, 1, None},
@@ -516,7 +516,7 @@ def test_difference(a, b):
     assert list((aorb ^ a).strings()) == [["b"]]
 
 
-def test_empty(a, b):
+def test_empty(a: FixtureA, b: FixtureB) -> None:
     assert not a.empty()
     assert not b.empty()
 
@@ -550,11 +550,11 @@ def test_empty(a, b):
     ).empty()
 
 
-def test_equivalent(a, b):
+def test_equivalent(a: FixtureA, b: FixtureB) -> None:
     assert (a | b).equivalent(b | a)
 
 
-def test_eq_ne(a, b):
+def test_eq_ne(a: FixtureA, b: FixtureB) -> None:
     # pylint: disable=comparison-with-itself
 
     assert a == a
@@ -574,7 +574,7 @@ def test_eq_ne(a, b):
         ("a",),
     ),
 )
-def test_eq_ne_het(a, other):
+def test_eq_ne_het(a: FixtureA, other: object) -> None:
     # pylint: disable=comparison-with-itself
 
     # eq
@@ -588,7 +588,7 @@ def test_eq_ne_het(a, other):
     assert other != a
 
 
-def test_dead_default():
+def test_dead_default() -> None:
     """
     You may now omit a transition, or even an entire state, from the map.
     This affects every usage of `Fsm.map`.
@@ -639,7 +639,7 @@ def test_dead_default():
     assert next(gen) == ["/", "*", "*", "/"]
 
 
-def test_alphabet_unions():
+def test_alphabet_unions() -> None:
     # Thanks to sparse maps it should now be possible to compute the union of
     # FSMs with disagreeing alphabets!
     a = Fsm(
@@ -670,7 +670,7 @@ def test_alphabet_unions():
     assert (a ^ b).accepts(["b"])
 
 
-def test_new_set_methods(a, b):
+def test_new_set_methods(a: FixtureA, b: FixtureB) -> None:
     # A whole bunch of new methods were added to the FSM module to enable FSMs
     # to function exactly as if they were sets of strings (symbol lists), see:
     # https://docs.python.org/3/library/stdtypes.html#set-types-set-frozenset
@@ -733,10 +733,10 @@ def test_new_set_methods(a, b):
     assert list(Fsm.concatenate().strings()) == []
 
 
-def test_copy(a):
+def test_copy(a: FixtureA) -> None:
     # fsm.copy() and frozenset().copy() both preserve identity, because they
     # are immutable. This is just showing that we give the same behaviour.
-    copyables = (a, frozenset("abc"))
+    copyables: tuple[Fsm | frozenset[str], ...] = (a, frozenset("abc"))
     for x in copyables:
         assert x.copy() is x
 
@@ -745,7 +745,7 @@ def test_copy(a):
         assert copy(x) is x
 
 
-def test_oblivion_crawl(a):
+def test_oblivion_crawl(a: FixtureA) -> None:
     # When crawling a new FSM, we should avoid generating an oblivion state.
     # `abc` has no oblivion state... all the results should not as well!
     abc = Fsm(
@@ -769,13 +769,13 @@ def test_oblivion_crawl(a):
     assert len((abc - abc).states) == 1
 
 
-def test_concatenate_bug(a):
+def test_concatenate_bug(a: FixtureA) -> None:
     # This exposes a defect in Fsm.concatenate.
     assert Fsm.concatenate(a, epsilon({"a"}), a).accepts("aa")
     assert Fsm.concatenate(a, epsilon({"a"}), epsilon({"a"}), a).accepts("aa")
 
 
-def test_derive(a, b):
+def test_derive(a: FixtureA, b: FixtureB) -> None:
     # Just some basic tests because this is mainly a regex thing.
     assert a.derive("a") == epsilon({"a", "b"})
     assert a.derive("b") == null({"a", "b"})
@@ -787,7 +787,7 @@ def test_derive(a, b):
     assert (a.star() - epsilon({"a", "b"})).derive("a") == a.star()
 
 
-def test_bug_36():
+def test_bug_36() -> None:
     etc1 = Fsm(
         alphabet={ANYTHING_ELSE},
         states={0},
@@ -821,7 +821,7 @@ def test_bug_36():
     assert both.accepts(["s"])
 
 
-def test_add_anything_else():
+def test_add_anything_else() -> None:
     # [^a]
     fsm1 = Fsm(
         alphabet={"a", ANYTHING_ELSE},
@@ -842,11 +842,11 @@ def test_add_anything_else():
     assert (fsm1 + fsm2).accepts("ba")
 
 
-def test_anything_else_singleton():
+def test_anything_else_singleton() -> None:
     assert AnythingElse.TOKEN is ANYTHING_ELSE
 
 
-def test_anything_else_self():
+def test_anything_else_self() -> None:
     """ANYTHING_ELSE is consistently equal to itself."""
 
     # pylint: disable=comparison-with-itself
@@ -871,7 +871,7 @@ def test_anything_else_self():
         str(ANYTHING_ELSE),
     ),
 )
-def test_anything_else_sorts_after(val):
+def test_anything_else_sorts_after(val: object) -> None:
     """ANYTHING_ELSE sorts strictly after anything."""
 
     # pylint: disable=unneeded-not
@@ -890,7 +890,7 @@ def test_anything_else_sorts_after(val):
     assert not val >= ANYTHING_ELSE
 
 
-def test_anything_else_pickle():
+def test_anything_else_pickle() -> None:
     # [^z]
     fsm1 = Fsm(
         alphabet={"z", ANYTHING_ELSE},

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -554,6 +554,41 @@ def test_equivalent(a, b):
     assert (a | b).equivalent(b | a)
 
 
+def test_eq_ne(a, b):
+    # pylint: disable=comparison-with-itself
+
+    assert a == a
+    assert b == b
+    assert a != b
+    assert b != a
+    assert (a | b) == (b | a)
+
+
+@pytest.mark.xfail(reason="BUG: __eq__ does not check type")
+@pytest.mark.parametrize(
+    argnames="other",
+    argvalues=(
+        17,
+        (14,),
+        "blenny",
+        "a",
+        ("a",),
+    ),
+)
+def test_eq_ne_het(a, other):
+    # pylint: disable=comparison-with-itself
+
+    # eq
+    assert not a == other
+    # eq, symmetric
+    assert not other == a
+
+    # neq
+    assert a != other
+    # neq, symmetric
+    assert other != a
+
+
 def test_dead_default():
     """
     You may now omit a transition, or even an entire state, from the map.

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -584,7 +584,13 @@ def test_dead_default():
     blockquote | blockquote
     blockquote & blockquote
     blockquote ^ blockquote
-    reversed(blockquote)
+    # Fsm does not support the `Reversible` protocol, because its
+    # `__reversed__` implementation does not return an iterator.
+    # Even if it did, it would not conform semantically because it returns an
+    # iterable of the reversed strings, not a reversed iteration of those
+    # strings.
+    # reversed(blockquote)
+    blockquote.reversed()
     assert not blockquote.everythingbut() \
         .accepts(["/", "*", "whatever", "*", "/"])
 

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -564,7 +564,6 @@ def test_eq_ne(a, b):
     assert (a | b) == (b | a)
 
 
-@pytest.mark.xfail(reason="BUG: __eq__ does not check type")
 @pytest.mark.parametrize(
     argnames="other",
     argvalues=(

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -428,7 +428,7 @@ def test_invalid_fsms():
             alphabet={},
             states={},
             initial=1,
-            finals=set(),
+            finals=(),
             map={}
         )
 
@@ -448,7 +448,7 @@ def test_invalid_fsms():
             alphabet={"a"},
             states={1},
             initial=1,
-            finals=set(),
+            finals=(),
             map={
                 1: {"a": 2}
             }
@@ -460,7 +460,7 @@ def test_invalid_fsms():
             alphabet={"a"},
             states={1, 2},
             initial=1,
-            finals=set(),
+            finals=(),
             map={
                 3: {"a": 2}
             }
@@ -472,7 +472,7 @@ def test_invalid_fsms():
             alphabet={"a"},
             states={1, 2},
             initial=1,
-            finals=set(),
+            finals=(),
             map={1: {"a": 2, "b": 2}},
         )
 

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pickle
+from copy import copy
 
 import pytest
 
@@ -697,6 +698,10 @@ def test_copy(a):
     copyables = (a, frozenset("abc"))
     for x in copyables:
         assert x.copy() is x
+
+    # Same, via the `__copy__` method.
+    for x in copyables:
+        assert copy(x) is x
 
 
 def test_oblivion_crawl(a):

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -287,15 +287,16 @@ def test_star_advanced():
 
 def test_reduce():
     # FSM accepts no strings but has 3 states, needs only 1
+    symbol = ()
     asdf = Fsm(
-        alphabet={None},
+        alphabet={symbol},
         states={0, 1, 2},
         initial=0,
         finals={1},
         map={
-            0: {None: 2},
-            1: {None: 2},
-            2: {None: 2},
+            0: {symbol: 2},
+            1: {symbol: 2},
+            2: {symbol: 2},
         },
     )
     asdf = asdf.reduce()

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -689,7 +689,14 @@ def test_new_set_methods(a, b):
     assert list(a.concatenate().strings()) == [["a"]]
     assert list(Fsm.concatenate(b, a, b).strings()) == [["b", "a", "b"]]
     assert list(Fsm.concatenate().strings()) == []
-    assert not a.copy() is a
+
+
+def test_copy(a):
+    # fsm.copy() and frozenset().copy() both preserve identity, because they
+    # are immutable. This is just showing that we give the same behaviour.
+    copyables = (a, frozenset("abc"))
+    for x in copyables:
+        assert x.copy() is x
 
 
 def test_oblivion_crawl(a):

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -413,7 +413,7 @@ def test_base_N():
     N = 3
     assert base <= 10
     divN = from_fsm(Fsm(
-        alphabet=set(str(i) for i in range(base)),
+        alphabet={str(i) for i in range(base)},
         states=set(range(N)) | {"initial", "zero", None},
         initial="initial",
         finals={"zero", 0},
@@ -467,7 +467,7 @@ def test_bad_alphabet():
             alphabet={bad_symbol},
             states={0},
             initial=0,
-            finals=set(),
+            finals=(),
             map={
                 0: {bad_symbol: 0}
             },


### PR DESCRIPTION
This gives `Fsm` properly contravariant constructor types, so that the inputs can be general `Iterable[str]` but read-only types are exposed.

It then types all of the methods, so that it passes `mypy --strict greenery/fsm{,_test}.py`.

There are a couple minor fixes, as well:
  * `copy()` returns `self`, as `frozenset(…).copy()` does.
  * `__eq__` (e.g. `a == "x"`) no longer throws `AttributeError` when compared to a different type.