### PR TITLE
Bound: type fixes + some basic missing tests

### DIFF
--- a/greenery/bound.py
+++ b/greenery/bound.py
@@ -16,38 +16,38 @@ class Bound:
 
     v: int | None
 
-    def __post_init__(self):
+    def __post_init__(self, /):
         if self.v is not None and self.v < 0:
             raise Exception(f"Invalid bound: {self.v!r}")
 
-    def __repr__(self):
+    def __repr__(self, /):
         return f"Bound({self.v!r})"
 
-    def __str__(self):
+    def __str__(self, /):
         if self.v is None:
             # This only happens for an unlimited upper bound
             return ""
         return str(self.v)
 
-    def __eq__(self, other):
+    def __eq__(self, other, /):
         if not isinstance(other, type(self)):
             return NotImplemented
         return self.v == other.v
 
-    def __hash__(self):
+    def __hash__(self, /):
         return hash(self.v)
 
-    def __lt__(self, other):
+    def __lt__(self, other, /):
         if self.v is None:
             return False
         if other.v is None:
             return True
         return self.v < other.v
 
-    def __ge__(self, other):
+    def __ge__(self, other, /):
         return not self < other
 
-    def __mul__(self, other):
+    def __mul__(self, other, /):
         """Multiply this bound by another"""
         if self == Bound(0) or other == Bound(0):
             return Bound(0)
@@ -55,13 +55,13 @@ class Bound:
             return INF
         return Bound(self.v * other.v)
 
-    def __add__(self, other):
+    def __add__(self, other, /):
         """Add this bound to another"""
         if self.v is None or other.v is None:
             return INF
         return Bound(self.v + other.v)
 
-    def __sub__(self, other):
+    def __sub__(self, other, /):
         """
         Subtract another bound from this one.
         Caution: this operation is not meaningful for all bounds.
@@ -80,7 +80,7 @@ class Bound:
             return INF
         return Bound(self.v - other.v)
 
-    def copy(self):
+    def copy(self, /):
         return Bound(self.v)
 
 

--- a/greenery/bound.py
+++ b/greenery/bound.py
@@ -24,7 +24,7 @@ class Bound:
         return f"Bound({self.v!r})"
 
     def __str__(self):
-        if self == INF:
+        if self.v is None:
             # This only happens for an unlimited upper bound
             return ""
         return str(self.v)
@@ -38,9 +38,9 @@ class Bound:
         return hash(self.v)
 
     def __lt__(self, other):
-        if self == INF:
+        if self.v is None:
             return False
-        if other == INF:
+        if other.v is None:
             return True
         return self.v < other.v
 
@@ -51,13 +51,13 @@ class Bound:
         """Multiply this bound by another"""
         if self == Bound(0) or other == Bound(0):
             return Bound(0)
-        if self == INF or other == INF:
+        if self.v is None or other.v is None:
             return INF
         return Bound(self.v * other.v)
 
     def __add__(self, other):
         """Add this bound to another"""
-        if self == INF or other == INF:
+        if self.v is None or other.v is None:
             return INF
         return Bound(self.v + other.v)
 
@@ -66,8 +66,8 @@ class Bound:
         Subtract another bound from this one.
         Caution: this operation is not meaningful for all bounds.
         """
-        if other == INF:
-            if self != INF:
+        if other.v is None:
+            if self.v is not None:
                 raise Exception(
                     f"Can't subtract {other!r} from {self!r}"
                 )
@@ -76,8 +76,8 @@ class Bound:
             # we can for example subtract Multiplier(Bound(0), INF) from
             # Multiplier(Bound(1), INF) to get Multiplier(Bound(1), Bound(1))
             return Bound(0)
-        if self == INF:
-            return self
+        if self.v is None:
+            return INF
         return Bound(self.v - other.v)
 
     def copy(self):

--- a/greenery/bound.py
+++ b/greenery/bound.py
@@ -30,6 +30,8 @@ class Bound:
         return str(self.v)
 
     def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
         return self.v == other.v
 
     def __hash__(self):

--- a/greenery/bound.py
+++ b/greenery/bound.py
@@ -7,8 +7,6 @@ __all__ = (
 
 from dataclasses import dataclass
 
-# mypy: allow-untyped-defs
-
 
 @dataclass(frozen=True)
 class Bound:
@@ -16,38 +14,38 @@ class Bound:
 
     v: int | None
 
-    def __post_init__(self, /):
+    def __post_init__(self, /) -> None:
         if self.v is not None and self.v < 0:
             raise Exception(f"Invalid bound: {self.v!r}")
 
-    def __repr__(self, /):
+    def __repr__(self, /) -> str:
         return f"Bound({self.v!r})"
 
-    def __str__(self, /):
+    def __str__(self, /) -> str:
         if self.v is None:
             # This only happens for an unlimited upper bound
             return ""
         return str(self.v)
 
-    def __eq__(self, other, /):
+    def __eq__(self, other: object, /) -> bool:
         if not isinstance(other, type(self)):
             return NotImplemented
         return self.v == other.v
 
-    def __hash__(self, /):
+    def __hash__(self, /) -> int:
         return hash(self.v)
 
-    def __lt__(self, other, /):
+    def __lt__(self, other: Bound, /) -> bool:
         if self.v is None:
             return False
         if other.v is None:
             return True
         return self.v < other.v
 
-    def __ge__(self, other, /):
+    def __ge__(self, other: Bound, /) -> bool:
         return not self < other
 
-    def __mul__(self, other, /):
+    def __mul__(self, other: Bound, /) -> Bound:
         """Multiply this bound by another"""
         if self == Bound(0) or other == Bound(0):
             return Bound(0)
@@ -55,13 +53,13 @@ class Bound:
             return INF
         return Bound(self.v * other.v)
 
-    def __add__(self, other, /):
+    def __add__(self, other: Bound, /) -> Bound:
         """Add this bound to another"""
         if self.v is None or other.v is None:
             return INF
         return Bound(self.v + other.v)
 
-    def __sub__(self, other, /):
+    def __sub__(self, other: Bound, /) -> Bound:
         """
         Subtract another bound from this one.
         Caution: this operation is not meaningful for all bounds.
@@ -80,7 +78,7 @@ class Bound:
             return INF
         return Bound(self.v - other.v)
 
-    def copy(self, /):
+    def copy(self, /) -> Bound:
         return Bound(self.v)
 
 

--- a/greenery/bound_test.py
+++ b/greenery/bound_test.py
@@ -28,7 +28,6 @@ def test_eq_neq():
     assert Bound(None) == INF
 
 
-@pytest.mark.xfail(raises=AttributeError, reason="BUG: __eq__does not check type")
 def test_eq_neq_heterogeneous():
     assert Bound(1) != "blah"
 

--- a/greenery/bound_test.py
+++ b/greenery/bound_test.py
@@ -1,8 +1,109 @@
 from __future__ import annotations
 
+import pytest
+
 from .bound import INF, Bound
 
 # mypy: allow-untyped-defs
+
+
+def test_ctor():
+    assert Bound(None) == INF
+
+    Bound(0)
+    Bound(1)
+    Bound(2)
+
+    with pytest.raises(Exception):
+        Bound(-1)
+
+
+def test_eq_neq():
+    # pylint: disable=comparison-with-itself
+    assert Bound(0) == Bound(0)
+    assert INF == INF
+    assert Bound(0) != Bound(1)
+    assert Bound(0) != INF
+    assert Bound(1) == Bound(1)
+    assert Bound(None) == INF
+
+
+@pytest.mark.xfail(raises=AttributeError, reason="BUG: __eq__does not check type")
+def test_eq_neq_heterogeneous():
+    assert Bound(1) != "blah"
+
+
+def test_comparisons():
+    # pylint: disable=comparison-with-itself
+    # pylint: disable=unneeded-not
+
+    assert Bound(0) < Bound(1)
+    assert Bound(0) < INF
+    assert Bound(1) < INF
+    assert not INF < INF
+
+
+def test_multiplication():
+    assert Bound(0) * Bound(0) == Bound(0)
+    assert Bound(0) * Bound(1) == Bound(0)
+    assert Bound(0) * Bound(2) == Bound(0)
+    assert Bound(0) * Bound(5) == Bound(0)
+    assert Bound(0) * INF == Bound(0)
+
+    assert Bound(1) * Bound(5) == Bound(5)
+    assert Bound(2) * Bound(5) == Bound(10)
+    assert Bound(0) * INF == Bound(0)
+    assert Bound(2) * INF == INF
+    assert INF * INF == INF
+    assert INF * Bound(0) == Bound(0)
+    assert Bound(1) * Bound(0) == Bound(0)
+
+
+def test_addition():
+    assert Bound(0) + Bound(0) == Bound(0)
+    assert Bound(0) + Bound(1) == Bound(1)
+    assert Bound(0) + Bound(5) == Bound(5)
+    assert Bound(0) + INF == INF
+
+    assert Bound(1) + Bound(0) == Bound(1)
+    assert Bound(1) + Bound(1) == Bound(2)
+    assert Bound(1) + Bound(5) == Bound(6)
+    assert Bound(1) + INF == INF
+
+    assert INF + Bound(0) == INF
+    assert INF + Bound(1) == INF
+    assert INF + INF == INF
+
+
+def test_subtraction():
+    assert Bound(0) - Bound(0) == Bound(0)
+    assert Bound(1) - Bound(0) == Bound(1)
+    assert Bound(6) - Bound(4) == Bound(2)
+    assert Bound(5) - Bound(5) == Bound(0)
+
+    assert INF - Bound(0) == INF
+    assert INF - Bound(1) == INF
+    assert INF - Bound(1000) == INF
+    assert INF - INF == Bound(0)
+
+    with pytest.raises(Exception):
+        _ = Bound(5) - Bound(6)
+
+    with pytest.raises(Exception):
+        _ = Bound(0) - Bound(1)
+
+    with pytest.raises(Exception):
+        _ = Bound(0) - INF
+
+    with pytest.raises(Exception):
+        _ = Bound(10) - INF
+
+
+def test_copy():
+    assert INF.copy() == INF
+
+    b = Bound(6)
+    assert b.copy() == b
 
 
 def test_bound_str():

--- a/greenery/bound_test.py
+++ b/greenery/bound_test.py
@@ -4,10 +4,8 @@ import pytest
 
 from .bound import INF, Bound
 
-# mypy: allow-untyped-defs
 
-
-def test_ctor():
+def test_ctor() -> None:
     assert Bound(None) == INF
 
     Bound(0)
@@ -18,7 +16,7 @@ def test_ctor():
         Bound(-1)
 
 
-def test_eq_neq():
+def test_eq_neq() -> None:
     # pylint: disable=comparison-with-itself
     assert Bound(0) == Bound(0)
     assert INF == INF
@@ -28,11 +26,11 @@ def test_eq_neq():
     assert Bound(None) == INF
 
 
-def test_eq_neq_heterogeneous():
+def test_eq_neq_heterogeneous() -> None:
     assert Bound(1) != "blah"
 
 
-def test_comparisons():
+def test_comparisons() -> None:
     # pylint: disable=comparison-with-itself
     # pylint: disable=unneeded-not
 
@@ -42,7 +40,7 @@ def test_comparisons():
     assert not INF < INF
 
 
-def test_multiplication():
+def test_multiplication() -> None:
     assert Bound(0) * Bound(0) == Bound(0)
     assert Bound(0) * Bound(1) == Bound(0)
     assert Bound(0) * Bound(2) == Bound(0)
@@ -58,7 +56,7 @@ def test_multiplication():
     assert Bound(1) * Bound(0) == Bound(0)
 
 
-def test_addition():
+def test_addition() -> None:
     assert Bound(0) + Bound(0) == Bound(0)
     assert Bound(0) + Bound(1) == Bound(1)
     assert Bound(0) + Bound(5) == Bound(5)
@@ -74,7 +72,7 @@ def test_addition():
     assert INF + INF == INF
 
 
-def test_subtraction():
+def test_subtraction() -> None:
     assert Bound(0) - Bound(0) == Bound(0)
     assert Bound(1) - Bound(0) == Bound(1)
     assert Bound(6) - Bound(4) == Bound(2)
@@ -98,18 +96,18 @@ def test_subtraction():
         _ = Bound(10) - INF
 
 
-def test_copy():
+def test_copy() -> None:
     assert INF.copy() == INF
 
     b = Bound(6)
     assert b.copy() == b
 
 
-def test_bound_str():
+def test_bound_str() -> None:
     assert str(Bound(2)) == "2"
     assert str(INF) == ""
 
 
-def test_bound():
+def test_bound() -> None:
     assert min(Bound(0), INF) == Bound(0)
     assert min(Bound(1), INF) == Bound(1)


### PR DESCRIPTION
This adds some basic tests to `bound_test.py`, fixes a bug in `__eq__`, and adds type annotations. This allows `mypy --strict greenery/bound{,_test}.py` to pass.