### PR TITLE
Charclass: bulk union/intersection methods

### DIFF
--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -257,6 +257,22 @@ class Charclass:
             else:
                 return Charclass(self.chars | other.chars)
 
+    def __and__(self, other: Charclass, /) -> Charclass:
+        # ¬A AND ¬B = ¬(A OR B)
+        # ¬A AND B = B - A
+        # A AND ¬B = A - B
+        # A AND B
+        if self.negated:
+            if other.negated:
+                return ~Charclass(self.chars | other.chars)
+            else:
+                return Charclass(other.chars - self.chars)
+        else:
+            if other.negated:
+                return Charclass(self.chars - other.chars)
+            else:
+                return Charclass(self.chars & other.chars)
+
 
 # Standard character classes
 WORDCHAR = Charclass(

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -257,12 +257,14 @@ class Charclass:
 
     __or__ = union
 
-    def __and__(self, other: Charclass, /) -> Charclass:
+    def intersection(*predicates: Charclass) -> Charclass:
         # ¬A AND ¬B = ¬(A OR B)
         # ¬A AND B = B - A
         # A AND ¬B = A - B
         # A AND B
-        return ~((~self) | (~other))
+        return ~Charclass.union(*(~cc for cc in predicates))
+
+    __and__ = intersection
 
 
 # Standard character classes

--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -262,16 +262,7 @@ class Charclass:
         # ¬A AND B = B - A
         # A AND ¬B = A - B
         # A AND B
-        if self.negated:
-            if other.negated:
-                return ~Charclass(self.chars | other.chars)
-            else:
-                return Charclass(other.chars - self.chars)
-        else:
-            if other.negated:
-                return Charclass(self.chars - other.chars)
-            else:
-                return Charclass(self.chars & other.chars)
+        return ~((~self) | (~other))
 
 
 # Standard character classes

--- a/greenery/charclass_test.py
+++ b/greenery/charclass_test.py
@@ -127,6 +127,14 @@ def test_charclass_intersection() -> None:
     # [^ab] ∩ [^bc] = [^abc]
     assert ~Charclass("ab") & ~Charclass("bc") == ~Charclass("abc")
 
+    assert Charclass.intersection(
+        Charclass("ab"),
+        Charclass("bcd"),
+        Charclass("abcde"),
+    ) == Charclass("b")
+
+    assert Charclass.intersection() == ~NULLCHARCLASS
+
 
 def test_empty() -> None:
     assert NULLCHARCLASS.empty()

--- a/greenery/charclass_test.py
+++ b/greenery/charclass_test.py
@@ -103,6 +103,19 @@ def test_charclass_union() -> None:
     # [^ab] ∪ [^bc] = [^b]
     assert ~Charclass("ab") | ~Charclass("bc") == ~Charclass("b")
 
+    assert Charclass.union() == NULLCHARCLASS
+
+    assert Charclass.union(
+        Charclass("ab"),
+        Charclass("a"),
+        Charclass("cd"),
+    ) == Charclass("abcd")
+
+    assert Charclass.union(
+        Charclass("ab"),
+        ~Charclass("abc"),
+    ) == ~Charclass("c")
+
 
 def test_charclass_intersection() -> None:
     # [ab] ∩ [bc] = [b]

--- a/greenery/charclass_test.py
+++ b/greenery/charclass_test.py
@@ -104,6 +104,17 @@ def test_charclass_union() -> None:
     assert ~Charclass("ab") | ~Charclass("bc") == ~Charclass("b")
 
 
+def test_charclass_intersection() -> None:
+    # [ab] ∩ [bc] = [b]
+    assert Charclass("ab") & Charclass("bc") == Charclass("b")
+    # [ab] ∩ [^bc] = [a]
+    assert Charclass("ab") & ~Charclass("bc") == Charclass("a")
+    # [^ab] ∩ [bc] = [c]
+    assert ~Charclass("ab") & Charclass("bc") == Charclass("c")
+    # [^ab] ∩ [^bc] = [^abc]
+    assert ~Charclass("ab") & ~Charclass("bc") == ~Charclass("abc")
+
+
 def test_empty() -> None:
     assert NULLCHARCLASS.empty()
     assert not DOT.empty()

--- a/greenery/charclass_test.py
+++ b/greenery/charclass_test.py
@@ -93,6 +93,17 @@ def test_charclass_negation() -> None:
     assert Charclass("a") == ~~Charclass("a")
 
 
+def test_charclass_union() -> None:
+    # [ab] ∪ [bc] = [abc]
+    assert Charclass("ab") | Charclass("bc") == Charclass("abc")
+    # [ab] ∪ [^bc] = [^c]
+    assert Charclass("ab") | ~Charclass("bc") == ~Charclass("c")
+    # [^a] ∪ [bc] = [^a]
+    assert ~Charclass("ab") | Charclass("bc") == ~Charclass("a")
+    # [^ab] ∪ [^bc] = [^b]
+    assert ~Charclass("ab") | ~Charclass("bc") == ~Charclass("b")
+
+
 def test_empty() -> None:
     assert NULLCHARCLASS.empty()
     assert not DOT.empty()

--- a/greenery/charclass_test.py
+++ b/greenery/charclass_test.py
@@ -83,11 +83,9 @@ def test_charclass_fsm() -> None:
     # "[^a]"
     nota = (~Charclass("a")).to_fsm()
     assert nota.alphabet == {"a", ANYTHING_ELSE}
-
-    # Fsm methods are not yet typed.
-    assert nota.accepts("b")  # type: ignore
-    assert nota.accepts(["b"])  # type: ignore
-    assert nota.accepts([ANYTHING_ELSE])  # type: ignore
+    assert nota.accepts("b")
+    assert nota.accepts(["b"])
+    assert nota.accepts([ANYTHING_ELSE])
 
 
 def test_charclass_negation() -> None:

--- a/greenery/fsm.py
+++ b/greenery/fsm.py
@@ -268,7 +268,10 @@ class Fsm:
         """
         alphabet = set().union(*[fsm.alphabet for fsm in fsms])
 
-        def connect_all(i: int, substate: state_type) -> Iterable[tuple[int, state_type]]:
+        def connect_all(
+            i: int,
+            substate: state_type,
+        ) -> Iterable[tuple[int, state_type]]:
             """
             Take a state in the numbered FSM and return a set containing
             it, plus (if it's final) the first state from the next FSM,

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -145,20 +145,11 @@ def match_class_interior(string, i):
         while True:
             # Match an internal character, range, or other charclass predicate.
             internal, internal_negated, i = match_class_interior_1(string, i)
-            predicates.append((internal, internal_negated))
+            predicates.append(Charclass(internal, negated=internal_negated))
     except NoMatch:
         pass
 
-    closed_sets = [chars for chars, negated in predicates if not negated]
-    include = frozenset.union(*closed_sets) if closed_sets else frozenset()
-
-    open_sets = [chars for chars, negated in predicates if negated]
-    exclude = frozenset.intersection(*open_sets) if open_sets else frozenset()
-
-    is_open = bool(open_sets)
-    chars = (exclude - include) if is_open else (include - exclude)
-
-    return chars, is_open, i
+    return Charclass.union(*predicates), i
 
 
 def match_charclass(string: str, i):
@@ -175,18 +166,18 @@ def match_charclass(string: str, i):
     # "[^dsgsdg]"
     try:
         j = static(string, i, "[^")
-        chars, negated, j = match_class_interior(string, j)
+        result, j = match_class_interior(string, j)
         j = static(string, j, "]")
-        return Charclass(chars, not negated), j
+        return ~result, j
     except NoMatch:
         pass
 
     # "[sdfsf]"
     try:
         j = static(string, i, "[")
-        chars, negated, j = match_class_interior(string, j)
+        result, j = match_class_interior(string, j)
         j = static(string, j, "]")
-        return Charclass(chars, negated), j
+        return result, j
     except NoMatch:
         pass
 


### PR DESCRIPTION
In #69, the incorrect combination of open (negated) charclasses was fixed in `greenery/parse.py`. The corrected logic was identical to that of bulk union/intersection of `Charclass` objects.

This moves that logic into the `Charclass` class and adds/restores tests around those methods.