### PR TITLE
rxelems.Pattern, Conc, Mult: type fixes

### DIFF
--- a/greenery/conc_test.py
+++ b/greenery/conc_test.py
@@ -7,11 +7,8 @@ from .charclass import Charclass
 from .multiplier import ONE, PLUS, QM, STAR, ZERO, Multiplier
 from .rxelems import Conc, Mult
 
-# mypy: allow-untyped-calls
-# mypy: allow-untyped-defs
 
-
-def test_conc_equality():
+def test_conc_equality() -> None:
     a = Conc(Mult(Charclass("a"), ONE))
     assert a == Conc(Mult(Charclass("a"), ONE))
     assert a != Conc(Mult(Charclass("b"), ONE))
@@ -20,7 +17,7 @@ def test_conc_equality():
     assert a != Conc()
 
 
-def test_conc_str():
+def test_conc_str() -> None:
     assert (
         str(
             Conc(
@@ -38,7 +35,7 @@ def test_conc_str():
     )
 
 
-def test_conc_common():
+def test_conc_common() -> None:
     a = Mult(Charclass("A"), ONE)
     b = Mult(Charclass("B"), ONE)
     c = Mult(Charclass("C"), ONE)
@@ -54,7 +51,7 @@ def test_conc_common():
     assert Conc(a).common(Conc(b), suffix=True) == Conc()
 
 
-def test_conc_dock():
+def test_conc_dock() -> None:
     a = Mult(Charclass("A"), ONE)
     b = Mult(Charclass("B"), ONE)
     x = Mult(Charclass("X"), ONE)
@@ -71,5 +68,5 @@ def test_conc_dock():
         Conc(x2, yplus, z).behead(Conc(x, yplus))
 
 
-def test_mult_reduction_easy():
+def test_mult_reduction_easy() -> None:
     assert Conc(Mult(Charclass("a"), ZERO)).reduce() == Conc()

--- a/greenery/mult_test.py
+++ b/greenery/mult_test.py
@@ -6,11 +6,8 @@ from .fsm import ANYTHING_ELSE
 from .multiplier import ONE, PLUS, QM, STAR, Multiplier
 from .rxelems import Mult
 
-# mypy: allow-untyped-calls
-# mypy: allow-untyped-defs
 
-
-def test_mult_equality():
+def test_mult_equality() -> None:
     a = Mult(Charclass("a"), ONE)
     assert a == a
     assert a != Mult(Charclass("b"), ONE)
@@ -18,7 +15,7 @@ def test_mult_equality():
     assert a != Mult(Charclass("a"), Multiplier(Bound(1), Bound(2)))
 
 
-def test_mult_str():
+def test_mult_str() -> None:
     a = Charclass("a")
     assert str(Mult(a, ONE)) == "a"
     assert str(Mult(a, Multiplier(Bound(2), Bound(2)))) == "a{2}"
@@ -36,7 +33,7 @@ def test_mult_str():
     assert str(Mult(DIGIT, Multiplier(Bound(3), Bound(3)))) == "\\d{3}"
 
 
-def test_odd_bug():
+def test_odd_bug() -> None:
     # Odd bug with ([bc]*c)?[ab]*
     int5A = Mult(
         Charclass("bc"),
@@ -57,7 +54,7 @@ def test_odd_bug():
     assert int5C.accepts(["c"])
 
 
-def test_mult_common():
+def test_mult_common() -> None:
     a = Charclass("a")
     assert Mult(a, Multiplier(Bound(3), Bound(4))).common(
         Mult(a, Multiplier(Bound(2), Bound(5)))
@@ -70,7 +67,7 @@ def test_mult_common():
     ) == Mult(a, Multiplier(Bound(2), INF))
 
 
-def test_mult_dock():
+def test_mult_dock() -> None:
     a = Charclass("a")
     assert Mult(a, Multiplier(Bound(4), Bound(5))).dock(
         Mult(a, Multiplier(Bound(3), Bound(3)))

--- a/greenery/pattern_test.py
+++ b/greenery/pattern_test.py
@@ -5,11 +5,8 @@ from .multiplier import ONE, ZERO
 from .parse import parse
 from .rxelems import Conc, Mult, Pattern
 
-# mypy: allow-untyped-calls
-# mypy: allow-untyped-defs
 
-
-def test_pattern_equality():
+def test_pattern_equality() -> None:
     assert Pattern(
         Conc(Mult(Charclass("a"), ONE)),
         Conc(Mult(Charclass("b"), ONE)),
@@ -25,7 +22,7 @@ def test_pattern_equality():
     )
 
 
-def test_pattern_str():
+def test_pattern_str() -> None:
     assert (
         str(
             Pattern(
@@ -78,11 +75,11 @@ def test_pattern_str():
     )
 
 
-def test_empty():
+def test_empty() -> None:
     assert Pattern().empty()
 
 
-def test_mult_reduction_easy():
+def test_mult_reduction_easy() -> None:
     assert Pattern(Conc()).reduce() == Pattern(Conc())
     assert Pattern(
         Conc(
@@ -107,11 +104,11 @@ def test_mult_reduction_easy():
     )
 
 
-def test_empty_pattern_reduction():
+def test_empty_pattern_reduction() -> None:
     assert str(Pattern().reduce()) == "[]"
 
 
-def test_empty_conc_suppression():
+def test_empty_conc_suppression() -> None:
     assert (
         str(
             Pattern(
@@ -127,7 +124,7 @@ def test_empty_conc_suppression():
     )
 
 
-def test_pattern_dock():
+def test_pattern_dock() -> None:
     a = Mult(Charclass("a"), ONE)
     c = Mult(Charclass("c"), ONE)
     f = Mult(Charclass("f"), ONE)
@@ -139,7 +136,7 @@ def test_pattern_dock():
     assert parse("aa").dock(Conc(a, a)) == parse("")
 
 
-def test_pattern_beheading():
+def test_pattern_beheading() -> None:
     a = Mult(Charclass("a"), ONE)
     c = Mult(Charclass("c"), ONE)
     f = Mult(Charclass("f"), ONE)

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -37,16 +37,16 @@ class Conc:
 
     mults: tuple[Mult, ...]
 
-    def __init__(self, *mults):
+    def __init__(self, /, *mults):
         object.__setattr__(self, "mults", tuple(mults))
 
-    def __eq__(self, other):
+    def __eq__(self, other, /):
         return self.mults == other.mults
 
-    def __hash__(self):
+    def __hash__(self, /):
         return hash(self.mults)
 
-    def __repr__(self):
+    def __repr__(self, /):
         args = ", ".join(repr(mult) for mult in self.mults)
         return f"Conc({args})"
 
@@ -89,7 +89,7 @@ class Conc:
                 r = self.mults[i]
                 s = self.mults[i + 1]
 
-                def to_pattern(multiplicand):
+                def to_pattern(multiplicand, /):
                     if isinstance(multiplicand, Pattern):
                         return multiplicand
                     return Pattern(Conc(Mult(multiplicand, ONE)))
@@ -152,7 +152,7 @@ class Conc:
 
         return self
 
-    def to_fsm(self, alphabet=None):
+    def to_fsm(self, /, alphabet=None):
         if alphabet is None:
             alphabet = self.alphabet()
 
@@ -162,16 +162,16 @@ class Conc:
             fsm1 += mult.to_fsm(alphabet)
         return fsm1
 
-    def alphabet(self):
+    def alphabet(self, /):
         return {ANYTHING_ELSE}.union(*[mult.alphabet() for mult in self.mults])
 
-    def empty(self):
+    def empty(self, /):
         return any(mult.empty() for mult in self.mults)
 
-    def __str__(self):
+    def __str__(self, /):
         return "".join(str(m) for m in self.mults)
 
-    def common(self, other, suffix=False):
+    def common(self, other, /, suffix=False):
         """
         Return the common prefix of these two `Conc`s; that is, the largest
         `Conc` which can be safely beheaded() from the front of both. The
@@ -217,7 +217,7 @@ class Conc:
 
         return Conc(*mults)
 
-    def dock(self, other):
+    def dock(self, other, /):
         """
         Subtract another `Conc` from this one.
         This is the opposite of concatenation.
@@ -247,7 +247,7 @@ class Conc:
 
         return Conc(*new)
 
-    def behead(self, other):
+    def behead(self, other, /):
         """
         As with dock() but the other way around. For example, if
         ABC + DEF = ABCDEF, then ABCDEF.behead(AB) = CDEF.
@@ -255,7 +255,7 @@ class Conc:
         # Observe that FEDCBA - BA = FEDC.
         return self.reversed().dock(other.reversed()).reversed()
 
-    def reversed(self):
+    def reversed(self, /):
         return Conc(*[mult.reversed() for mult in reversed(self.mults)])
 
 
@@ -406,26 +406,26 @@ class Pattern:
 
     concs: frozenset[Conc]
 
-    def __init__(self, *concs):
+    def __init__(self, /, *concs):
         object.__setattr__(self, "concs", frozenset(concs))
 
-    def __eq__(self, other):
+    def __eq__(self, other, /):
         return isinstance(other, Pattern) and self.concs == other.concs
 
-    def __hash__(self):
+    def __hash__(self, /):
         return hash(self.concs)
 
-    def __repr__(self):
+    def __repr__(self, /):
         args = ", ".join(repr(conc) for conc in self.concs)
         return f"Pattern({args})"
 
-    def alphabet(self):
+    def alphabet(self, /):
         return {ANYTHING_ELSE}.union(*[c.alphabet() for c in self.concs])
 
-    def empty(self):
+    def empty(self, /):
         return all(conc.empty() for conc in self.concs)
 
-    def intersection(self, other):
+    def intersection(self, other, /):
         # A deceptively simple method for an astoundingly difficult operation
         alphabet = self.alphabet() | other.alphabet()
 
@@ -434,7 +434,7 @@ class Pattern:
         combined = self.to_fsm(alphabet) & other.to_fsm(alphabet)
         return from_fsm(combined)
 
-    def __and__(self, other):
+    def __and__(self, other, /):
         return self.intersection(other)
 
     @call_fsm
@@ -445,21 +445,21 @@ class Pattern:
         """
         pass
 
-    def __sub__(self, other):
+    def __sub__(self, other, /):
         return self.difference(other)
 
-    def union(self, other):
+    def union(self, other, /):
         return Pattern(*(self.concs | other.concs))
 
-    def __or__(self, other):
+    def __or__(self, other, /):
         return self.union(other)
 
-    def __str__(self):
+    def __str__(self, /):
         if len(self.concs) == 0:
             raise Exception(f"Can't serialise {self!r}")
         return "|".join(sorted(str(conc) for conc in self.concs))
 
-    def reduce(self) -> Pattern:
+    def reduce(self, /) -> Pattern:
         if self == NULLPATTERN:
             return self
 
@@ -592,10 +592,10 @@ class Pattern:
         """
         pass
 
-    def __xor__(self, other):
+    def __xor__(self, other, /):
         return self.symmetric_difference(other)
 
-    def dock(self, other):
+    def dock(self, other, /):
         """
         The opposite of concatenation. Remove a common suffix from the
         present `Pattern`; that is, from each of its constituent concs.
@@ -604,7 +604,7 @@ class Pattern:
         """
         return Pattern(*[conc.dock(other) for conc in self.concs])
 
-    def behead(self, other):
+    def behead(self, other, /):
         """
         Like dock() but the other way around. Remove a common prefix from
         the present `Pattern`; that is, from each of its constituent concs.
@@ -613,7 +613,7 @@ class Pattern:
         """
         return Pattern(*[conc.behead(other) for conc in self.concs])
 
-    def _commonconc(self, suffix=False):
+    def _commonconc(self, /, suffix=False):
         """
         Find the longest `Conc` which acts as prefix to every `Conc` in
         this `Pattern`. This could be `EMPTYSTRING`. Return the common
@@ -631,7 +631,7 @@ class Pattern:
 
         return reduce(lambda x, y: x.common(y, suffix=suffix), self.concs)
 
-    def to_fsm(self, alphabet=None):
+    def to_fsm(self, /, alphabet=None):
         if alphabet is None:
             alphabet = self.alphabet()
 
@@ -640,17 +640,17 @@ class Pattern:
             fsm1 |= conc.to_fsm(alphabet)
         return fsm1
 
-    def reversed(self):
+    def reversed(self, /):
         return Pattern(*(c.reversed() for c in self.concs))
 
-    def copy(self):
+    def copy(self, /):
         """
         For completeness only, since `set.copy()` also exists. `Pattern`s
         are immutable, so I can see only very odd reasons to need this
         """
         return Pattern(*self.concs)
 
-    def equivalent(self, other):
+    def equivalent(self, other, /):
         """
         Two `Pattern`s are equivalent if they recognise the same strings.
         Note that in the general case this is actually quite an intensive
@@ -658,7 +658,7 @@ class Pattern:
         """
         return self.to_fsm().equivalent(other.to_fsm())
 
-    def times(self, multiplier):
+    def times(self, multiplier, /):
         """
         Equivalent to repeated concatenation. Multiplier consists of a
         minimum and a maximum; maximum may be infinite (for Kleene star
@@ -666,11 +666,11 @@ class Pattern:
         """
         return Pattern(Conc(Mult(self, multiplier)))
 
-    def __mul__(self, multiplier):
+    def __mul__(self, multiplier, /):
         return self.times(multiplier)
 
     @call_fsm
-    def everythingbut(self):
+    def everythingbut(self, /):
         """
         Return a `Pattern` which will match any string not matched by
         `self`, and which will not match any string matched by `self`.
@@ -680,30 +680,30 @@ class Pattern:
         """
         pass
 
-    def derive(self, string):
+    def derive(self, string, /):
         return from_fsm(self.to_fsm().derive(string))
 
-    def isdisjoint(self, other):
+    def isdisjoint(self, other, /):
         """
         Treat `self` and `other` as sets of strings and see if they are
         disjoint
         """
         return self.to_fsm().isdisjoint(other.to_fsm())
 
-    def matches(self, string):
+    def matches(self, string, /):
         return self.to_fsm().accepts(string)
 
-    def __contains__(self, string):
+    def __contains__(self, string, /):
         """
         This lets you use the syntax `"a" in pattern` to see whether the
         string "a" is in the set of strings matched by `pattern`.
         """
         return self.matches(string)
 
-    def __reversed__(self):
+    def __reversed__(self, /):
         return self.reversed()
 
-    def cardinality(self):
+    def cardinality(self, /):
         """
         Consider the regular expression as a set of strings and return the
         cardinality of that set, or raise an OverflowError if there are
@@ -713,10 +713,10 @@ class Pattern:
         # the `Pattern` may allow duplicate routes, such as "a|a".
         return self.to_fsm().cardinality()
 
-    def __len__(self):
+    def __len__(self, /):
         return self.cardinality()
 
-    def strings(self, otherchar=None):
+    def strings(self, /, *, otherchar=None):
         """
         Each time next() is called on this iterator, a new string is
         returned which this `Pattern` can match. `StopIteration`
@@ -740,7 +740,7 @@ class Pattern:
 
             yield "".join(string)
 
-    def __iter__(self):
+    def __iter__(self, /):
         """
         This allows you to do `for string in pattern` as a list
         comprehension!
@@ -763,20 +763,20 @@ class Mult:
     multiplicand: Charclass | Pattern
     multiplier: Multiplier
 
-    def __eq__(self, other):
+    def __eq__(self, other, /):
         return (
             isinstance(other.multiplicand, type(self.multiplicand))
             and self.multiplicand == other.multiplicand
             and self.multiplier == other.multiplier
         )
 
-    def __hash__(self):
+    def __hash__(self, /):
         return hash((self.multiplicand, self.multiplier))
 
-    def __repr__(self):
+    def __repr__(self, /):
         return f"Mult({self.multiplicand!r}, {self.multiplier!r})"
 
-    def dock(self, other):
+    def dock(self, other, /):
         """
         "Dock" another `Mult` from this one (i.e. remove part of the tail)
         and return the result. The reverse of concatenation. This is a lot
@@ -787,7 +787,7 @@ class Mult:
             raise Exception(f"Can't subtract {other!r} from {self!r}")
         return Mult(self.multiplicand, self.multiplier - other.multiplier)
 
-    def common(self, other):
+    def common(self, other, /):
         """
         Return the common part of these two mults. This is the largest
         `Mult` which can be safely subtracted from both the originals. The
@@ -800,13 +800,13 @@ class Mult:
         # Multiplicands disagree, no common part at all.
         return Mult(NULLCHARCLASS, ZERO)
 
-    def alphabet(self):
+    def alphabet(self, /):
         return {ANYTHING_ELSE} | self.multiplicand.alphabet()
 
-    def empty(self):
+    def empty(self, /):
         return self.multiplicand.empty() and self.multiplier.min > Bound(0)
 
-    def reduce(self) -> Mult:
+    def reduce(self, /) -> Mult:
         if self == NULLMULT:
             return self
 
@@ -856,14 +856,14 @@ class Mult:
         # no reduction possible
         return self
 
-    def __str__(self):
+    def __str__(self, /):
         if isinstance(self.multiplicand, Pattern):
             return f"({self.multiplicand}){self.multiplier}"
         if isinstance(self.multiplicand, Charclass):
             return f"{self.multiplicand}{self.multiplier}"
         raise Exception(f"Unknown type {type(self.multiplicand)}")
 
-    def to_fsm(self, alphabet=None):
+    def to_fsm(self, /, alphabet=None):
         if alphabet is None:
             alphabet = self.alphabet()
 
@@ -890,7 +890,7 @@ class Mult:
 
         return mandatory + optional
 
-    def reversed(self):
+    def reversed(self, /):
         return Mult(self.multiplicand.reversed(), self.multiplier)
 
 

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -869,6 +869,10 @@ class Mult:
         unit = self.multiplicand.to_fsm(alphabet)
         # accepts e.g. "ab"
 
+        # Yuck. `mandatory` cannot be infinite: it's just a natural number.
+        # However, it uses `Bound`, which describes co-naturals.
+        assert self.multiplier.mandatory.v is not None
+
         # accepts "ababababab"
         mandatory = unit * self.multiplier.mandatory.v
 
@@ -880,6 +884,9 @@ class Mult:
         else:
             optional = epsilon(alphabet) | unit
             # accepts "(ab)?"
+
+            # Implied by `!= INF`.
+            assert self.multiplier.optional.v is not None
 
             optional *= self.multiplier.optional.v
             # accepts "(ab)?(ab)?"

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -163,7 +163,8 @@ class Conc:
         return fsm1
 
     def alphabet(self, /):
-        return {ANYTHING_ELSE}.union(*[mult.alphabet() for mult in self.mults])
+        components = self.mults
+        return frozenset().union(*(c.alphabet() for c in components)) | {ANYTHING_ELSE}
 
     def empty(self, /):
         return any(mult.empty() for mult in self.mults)
@@ -380,7 +381,7 @@ def call_fsm(method):
     fsm_method = getattr(Fsm, method.__name__)
 
     def new_method(*elems):
-        alphabet = set().union(*[elem.alphabet() for elem in elems])
+        alphabet = frozenset().union(*(elem.alphabet() for elem in elems))
         return from_fsm(fsm_method(*[elem.to_fsm(alphabet) for elem in elems]))
 
     return new_method
@@ -420,7 +421,8 @@ class Pattern:
         return f"Pattern({args})"
 
     def alphabet(self, /):
-        return {ANYTHING_ELSE}.union(*[c.alphabet() for c in self.concs])
+        components = self.concs
+        return frozenset().union(*(c.alphabet() for c in components)) | {ANYTHING_ELSE}
 
     def empty(self, /):
         return all(conc.empty() for conc in self.concs)
@@ -801,7 +803,8 @@ class Mult:
         return Mult(NULLCHARCLASS, ZERO)
 
     def alphabet(self, /):
-        return {ANYTHING_ELSE} | self.multiplicand.alphabet()
+        components = (self.multiplicand,)
+        return frozenset().union(*(c.alphabet() for c in components)) | {ANYTHING_ELSE}
 
     def empty(self, /):
         return self.multiplicand.empty() and self.multiplier.min > Bound(0)

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -216,7 +216,7 @@ class Conc:
                 break
 
         if suffix:
-            mults = reversed(mults)
+            mults = mults[::-1]
 
         return Conc(*mults)
 

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -41,6 +41,8 @@ class Conc:
         object.__setattr__(self, "mults", tuple(mults))
 
     def __eq__(self, other, /):
+        if not isinstance(other, type(self)):
+            return NotImplemented
         return self.mults == other.mults
 
     def __hash__(self, /):
@@ -395,7 +397,9 @@ class Pattern:
         object.__setattr__(self, "concs", frozenset(concs))
 
     def __eq__(self, other, /):
-        return isinstance(other, Pattern) and self.concs == other.concs
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self.concs == other.concs
 
     def __hash__(self, /):
         return hash(self.concs)
@@ -751,9 +755,10 @@ class Mult:
     multiplier: Multiplier
 
     def __eq__(self, other, /):
+        if not isinstance(other, type(self)):
+            return NotImplemented
         return (
-            isinstance(other.multiplicand, type(self.multiplicand))
-            and self.multiplicand == other.multiplicand
+            self.multiplicand == other.multiplicand
             and self.multiplier == other.multiplier
         )
 

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -190,7 +190,7 @@ class Conc:
         """
         mults = []
 
-        indices = range(min(len(self.mults), len(other.mults)))
+        indices = list(range(min(len(self.mults), len(other.mults))))
         # e.g. [0, 1, 2, 3]
 
         # Work backwards from the end of both `Conc`s instead.

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -720,16 +720,19 @@ class Pattern:
         # match. It's not productive to iterate over all of these giving every
         # single example. You must supply your own "otherchar" to stand in for
         # all of these possibilities.
-        for string in self.to_fsm().strings():
+        for symbols in self.to_fsm().strings():
             # Have to represent `ANYTHING_ELSE` somehow.
-            if ANYTHING_ELSE in string:
-                if otherchar is None:
-                    raise Exception("Please choose an `otherchar`")
-                string = [
-                    otherchar if char is ANYTHING_ELSE else char for char in string
-                ]
+            chars = []
+            for symbol in symbols:
+                if isinstance(symbol, str):
+                    char = symbol
+                elif otherchar is not None:
+                    char = otherchar
+                else:
+                    raise TypeError("Please choose an `otherchar`")
+                chars.append(char)
 
-            yield "".join(string)
+            yield "".join(chars)
 
     def __iter__(self, /):
         """

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -421,7 +421,7 @@ def test_base_N():
     divN = from_fsm(
         Fsm(
             alphabet={str(i) for i in range(base)},
-            states=set(range(N)) | {"initial", "zero", None},
+            states=frozenset(range(N)) | {"initial", "zero", None},
             initial="initial",
             finals={"zero", 0},
             map=dict(

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -455,7 +455,16 @@ def test_bad_alphabet():
     # You can use anything you like in your FSM alphabet, but if you try to
     # convert it to an `rxelems` object then the only acceptable symbols are
     # single characters or `ANYTHING_ELSE`.
-    for bad_symbol in [None, (), 0, ("a",), "", "aa", "ab", True]:
+
+    # NOTE: This used to test with `None`, before type annotations were added.
+    # However, `None` is not `OrderedHashable` and can't be used with an `Fsm`
+    # alphabet at runtime to begin with, regardless of type annotations or even
+    # expanding `AlphabetType` to the most general usable constraints.
+    # By default, sorting a collection with `None` raises a `TypeError`.
+    # That has nothing to do with `from_fsm`.
+    bad_symbols = ((), 0, ("a",), "", "aa", "ab", True)
+
+    for bad_symbol in bad_symbols:
         f = Fsm(
             alphabet={bad_symbol},
             states={0},

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -365,9 +365,9 @@ def test_even_star_bug1():
     assert elesscomplex.accepts("a")
     assert not elesscomplex.accepts("aa")
     assert elesscomplex.accepts("aaa")
-    elesscomplex = from_fsm(elesscomplex)
-    assert str(elesscomplex) in {"a(a{2})*", "(a{2})*a"}
-    elesscomplex = elesscomplex.to_fsm()
+    elesscomplex_pat = from_fsm(elesscomplex)
+    assert str(elesscomplex_pat) in {"a(a{2})*", "(a{2})*a"}
+    elesscomplex = elesscomplex_pat.to_fsm()
     assert not elesscomplex.accepts("")
     assert elesscomplex.accepts("a")
     assert not elesscomplex.accepts("aa")
@@ -751,10 +751,10 @@ def test_silly_reduction():
         + "(aa|bb*aa)a*|((ab|bb*ab)|(aa|bb*aa)a*b)"
         + "((ab|bb*ab)|(aa|bb*aa)a*b)*"
     )
-    long = parse(long)
-    long = long.to_fsm().reversed()
-    long = from_fsm(long).reversed()
-    assert str(long) == "[ab]*a[ab]"
+    long_pat1 = parse(long)
+    long_fsm = long_pat1.to_fsm().reversed()
+    long_pat2 = from_fsm(long_fsm).reversed()
+    assert str(long_pat2) == "[ab]*a[ab]"
     short = "[ab]*a?b*|[ab]*b?a*"
     assert str(parse(".*") & parse(short)) == "[ab]*"
 

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pickle
 import time
+from typing import Any
 
 import pytest
 
@@ -9,10 +10,6 @@ from .charclass import DIGIT, WORDCHAR
 from .fsm import ANYTHING_ELSE, Fsm
 from .parse import parse
 from .rxelems import from_fsm
-
-# mypy: allow-untyped-calls
-# mypy: allow-untyped-defs
-# mypy: no-check-untyped-defs
 
 if __name__ == "__main__":
     raise Exception("Test files can't be run directly. Use `python -m pytest greenery`")
@@ -22,7 +19,7 @@ if __name__ == "__main__":
 # Stringification tests
 
 
-def test_charclass_str():
+def test_charclass_str() -> None:
     # Arbitrary ranges
     assert str(parse("[\\w:;<=>?@\\[\\\\\\]\\^`]")) == "[0-z]"
     # TODO: what if \d is a proper subset of `chars`?
@@ -34,7 +31,7 @@ def test_charclass_str():
     assert str(parse("\\x00")) == "\\x00"
 
 
-def test_parse_str_round_trip():
+def test_parse_str_round_trip() -> None:
     # not "a[ab]b"
     assert str(parse("a.b")) == "a.b"
     assert str(parse("\\d{4}")) == "\\d{4}"
@@ -45,12 +42,12 @@ def test_parse_str_round_trip():
 # Test to_fsm() and alphabet-related functionality
 
 
-def test_alphabet():
+def test_alphabet() -> None:
     # `.alphabet()` should include `ANYTHING_ELSE`
     assert parse("").alphabet() == {ANYTHING_ELSE}
 
 
-def test_pattern_fsm():
+def test_pattern_fsm() -> None:
     # "a[^a]"
     anota = parse("a[^a]").to_fsm()
     assert len(anota.states) == 3
@@ -88,7 +85,7 @@ def test_pattern_fsm():
     assert conventional.accepts("defjkl")
 
 
-def test_fsm():
+def test_fsm() -> None:
     # You should be able to to_fsm() a single regular expression element
     # without supplying a specific alphabet. That should be determinable from
     # context.
@@ -105,7 +102,7 @@ def test_fsm():
     assert not bad.accepts("01")
 
 
-def test_bug_28():
+def test_bug_28() -> None:
     # Starification was broken in FSMs
     assert not parse("(ab*)").to_fsm().star().accepts("bb")
     assert not parse("(ab*)*").to_fsm().accepts("bb")
@@ -115,14 +112,14 @@ def test_bug_28():
 # Test matches(). Quite sparse at the moment
 
 
-def test_wildcards_in_charclasses():
+def test_wildcards_in_charclasses() -> None:
     # Allow "\w", "\d" and "\s" in `Charclass`es
     assert parse("[\\w~]*").matches("a0~")
     assert parse("[\\da]*").matches("0129a")
     assert parse("[\\s]+").matches(" \t \t ")
 
 
-def test_block_comment_regex():
+def test_block_comment_regex() -> None:
     # I went through several incorrect regexes for C block comments. Here we
     # show why the first few attempts were incorrect
     a = parse("/\\*(([^*]|\\*+[^*/])*)\\*/")
@@ -141,12 +138,12 @@ def test_block_comment_regex():
     assert c.matches("/****/")
 
 
-def test_named_groups():
+def test_named_groups() -> None:
     a = parse("(?P<ng1>abc)")
     assert a.matches("abc")
 
 
-def test_in():
+def test_in() -> None:
     assert "a" in parse("a")
     assert "abcdsasda" in parse("\\w{4,10}")
     assert "abc" in parse("abc|def(ghi|jkl)")
@@ -156,7 +153,7 @@ def test_in():
 # Test string generators
 
 
-def test_charclass_gen():
+def test_charclass_gen() -> None:
     gen = parse("[xyz]").strings()
     assert next(gen) == "x"
     assert next(gen) == "y"
@@ -166,7 +163,7 @@ def test_charclass_gen():
         next(gen)
 
 
-def test_mult_gen():
+def test_mult_gen() -> None:
     # One term
     gen = parse("[ab]").strings()
     assert next(gen) == "a"
@@ -194,7 +191,7 @@ def test_mult_gen():
     assert next(gen) == "aaa"
 
 
-def test_conc_generator():
+def test_conc_generator() -> None:
     gen = parse("[ab][cd]").strings()
     assert next(gen) == "ac"
     assert next(gen) == "ad"
@@ -205,7 +202,7 @@ def test_conc_generator():
         next(gen)
 
 
-def test_pattern_generator():
+def test_pattern_generator() -> None:
     gen = parse("[ab]|[cde]").strings()
     assert next(gen) == "a"
     assert next(gen) == "b"
@@ -228,7 +225,7 @@ def test_pattern_generator():
     assert next(gen) == "002"
 
 
-def test_infinite_generation():
+def test_infinite_generation() -> None:
     # Infinite generator, flummoxes both depth-first and breadth-first searches
     gen = parse("a*b*").strings()
     assert next(gen) == ""
@@ -244,7 +241,7 @@ def test_infinite_generation():
     assert next(gen) == "aaaa"
 
 
-def test_wildcard_generator():
+def test_wildcard_generator() -> None:
     # Generator needs to handle wildcards as well. Wildcards come last.
     gen = parse("a.b").strings(otherchar="*")
     assert next(gen) == "aab"
@@ -255,7 +252,7 @@ def test_wildcard_generator():
         next(gen)
 
 
-def test_forin():
+def test_forin() -> None:
     assert [s for s in parse("abc|def(ghi|jkl)")] == ["abc", "defghi", "defjkl"]
 
 
@@ -263,7 +260,7 @@ def test_forin():
 # Test cardinality() and len()
 
 
-def test_cardinality():
+def test_cardinality() -> None:
     assert parse("[]").cardinality() == 0
     assert parse("[]?").cardinality() == 1
     assert parse("[]{0,6}").cardinality() == 1
@@ -278,7 +275,7 @@ def test_cardinality():
 ###############################################################################
 
 
-def test_copy():
+def test_copy() -> None:
     x = parse("abc|def(ghi|jkl)")
     assert x.copy() == x
 
@@ -287,12 +284,12 @@ def test_copy():
 # Test from_fsm()
 
 
-def test_dot():
+def test_dot() -> None:
     # not "a[ab]b"
     assert str(from_fsm(parse("a.b").to_fsm())) == "a.b"
 
 
-def test_abstar():
+def test_abstar() -> None:
     # Buggggs.
     abstar = Fsm(
         alphabet={"a", ANYTHING_ELSE, "b"},
@@ -307,7 +304,7 @@ def test_abstar():
     assert str(from_fsm(abstar)) == "[ab]*"
 
 
-def test_adotb():
+def test_adotb() -> None:
     adotb = Fsm(
         alphabet={"a", ANYTHING_ELSE, "b"},
         states={0, 1, 2, 3, 4},
@@ -324,7 +321,7 @@ def test_adotb():
     assert str(from_fsm(adotb)) == "a.b"
 
 
-def test_rxelems_recursion_error():
+def test_rxelems_recursion_error() -> None:
     # Catch a recursion error
     assert (
         str(
@@ -347,7 +344,7 @@ def test_rxelems_recursion_error():
     )
 
 
-def test_even_star_bug1():
+def test_even_star_bug1() -> None:
     # Bug fix. This is a(a{2})* (i.e. accepts an odd number of "a" chars in a
     # row), but when from_fsm() is called, the result is "a+". Turned out to be
     # a fault in the rxelems.multiplier.__mul__() routine
@@ -379,7 +376,7 @@ def test_even_star_bug1():
     assert next(gen) == ["a", "a", "a", "a", "a", "a", "a"]
 
 
-def test_binary_3():
+def test_binary_3() -> None:
     # Binary numbers divisible by 3.
     # Disallows the empty string
     # Allows "0" on its own, but not leading zeroes.
@@ -411,7 +408,7 @@ def test_binary_3():
     assert next(gen) == "1100"
 
 
-def test_base_N():
+def test_base_N() -> None:
     # Machine accepts only numbers in selected base (e.g. 2, 10) that are
     # divisible by N (e.g. 3, 7).
     # "0" alone is acceptable, but leading zeroes (e.g. "00", "07") are not
@@ -425,7 +422,7 @@ def test_base_N():
             initial="initial",
             finals={"zero", 0},
             map=dict(
-                [
+                [  # type: ignore
                     (
                         "initial",
                         dict(
@@ -451,7 +448,7 @@ def test_base_N():
         a = b
 
 
-def test_bad_alphabet():
+def test_bad_alphabet() -> None:
     # You can use anything you like in your FSM alphabet, but if you try to
     # convert it to an `rxelems` object then the only acceptable symbols are
     # single characters or `ANYTHING_ELSE`.
@@ -462,7 +459,7 @@ def test_bad_alphabet():
     # expanding `AlphabetType` to the most general usable constraints.
     # By default, sorting a collection with `None` raises a `TypeError`.
     # That has nothing to do with `from_fsm`.
-    bad_symbols = ((), 0, ("a",), "", "aa", "ab", True)
+    bad_symbols: tuple[Any, ...] = ((), 0, ("a",), "", "aa", "ab", True)
 
     for bad_symbol in bad_symbols:
         f = Fsm(
@@ -477,7 +474,7 @@ def test_bad_alphabet():
             from_fsm(f)
 
 
-def test_dead_default():
+def test_dead_default() -> None:
     blockquote = from_fsm(
         Fsm(
             alphabet={"/", "*", ANYTHING_ELSE},
@@ -499,14 +496,14 @@ def test_dead_default():
 # charclass set operations
 
 
-def test_charclass_union():
+def test_charclass_union() -> None:
     assert (parse("[ab]") | parse("[bc]")).reduce() == parse("[abc]")
     assert (parse("[ab]") | parse("[^bc]")).reduce() == parse("[^c]")
     assert (parse("[^ab]") | parse("[bc]")).reduce() == parse("[^a]")
     assert (parse("[^ab]") | parse("[^bc]")).reduce() == parse("[^b]")
 
 
-def test_charclass_intersection():
+def test_charclass_intersection() -> None:
     assert parse("[ab]") & parse("[bc]") == parse("b")
     assert parse("[ab]") & parse("[^bc]") == parse("a")
     assert parse("[^ab]") & parse("[bc]") == parse("c")
@@ -517,7 +514,7 @@ def test_charclass_intersection():
 # Emptiness detection
 
 
-def test_empty():
+def test_empty() -> None:
     assert not parse("a{0}").empty()
     assert parse("[]").empty()
     assert not parse("[]?").empty()
@@ -531,7 +528,7 @@ def test_empty():
 # Test everythingbut()
 
 
-def test_everythingbut():
+def test_everythingbut() -> None:
     # Regexes are usually gibberish but we make a few claims
     a = parse("a")
     notA = a.everythingbut().to_fsm()
@@ -550,7 +547,7 @@ def test_everythingbut():
     assert str(parse("[]").everythingbut()) == ".*"
 
 
-def test_isinstance_bug():
+def test_isinstance_bug() -> None:
     # Problem relating to isinstance(). The class `Mult` was occurring as both
     # rxelems.Mult and as __main__.Mult and apparently these count as different
     # classes for some reason, so isinstance(m, Mult) was returning false.
@@ -564,7 +561,7 @@ def test_isinstance_bug():
 ###############################################################################
 
 
-def test_equivalence():
+def test_equivalence() -> None:
     assert parse("aa*").equivalent(parse("a*a"))
     assert parse("([ab]*a|[bc]*c)?b*").equivalent(parse("b*(a[ab]*|c[bc]*)?"))
 
@@ -573,7 +570,7 @@ def test_equivalence():
 # Test reversed()
 
 
-def test_regex_reversal():
+def test_regex_reversal() -> None:
     assert parse("b").reversed() == parse("b")
     assert parse("e*").reversed() == parse("e*")
     assert parse("bear").reversed() == parse("raeb")
@@ -586,7 +583,7 @@ def test_regex_reversal():
 # Tests for some more set operations
 
 
-def test_set_ops():
+def test_set_ops() -> None:
     assert parse("[abcd]") - parse("a") == parse("[bcd]")
     assert parse("[abcd]") ^ parse("[cdef]") == parse("[abef]")
 
@@ -595,7 +592,7 @@ def test_set_ops():
 # Test methods for finding common parts of regular expressions.
 
 
-def test_pattern_commonconc():
+def test_pattern_commonconc() -> None:
     assert str(parse("aa|aa")._commonconc()) == "aa"
     assert str(parse("abc|aa")._commonconc()) == "a"
     assert str(parse("a|bc")._commonconc()) == ""
@@ -605,7 +602,7 @@ def test_pattern_commonconc():
     assert str(parse("a{2}b|a+c")._commonconc()) == "a"
 
 
-def test_pattern_commonconc_suffix():
+def test_pattern_commonconc_suffix() -> None:
     assert str(parse("a|bc")._commonconc(suffix=True)) == ""
     assert str(parse("aa|bca")._commonconc(suffix=True)) == "a"
     assert str(parse("xyza|abca|a")._commonconc(suffix=True)) == "a"
@@ -617,7 +614,7 @@ def test_pattern_commonconc_suffix():
 # Basic concatenation reduction tests
 
 
-def test_reduce_concatenations():
+def test_reduce_concatenations() -> None:
     assert str(parse("aa").reduce()) == "a{2}"
     assert str(parse("bb").reduce()) == "b{2}"
     assert str(parse("b*b").reduce()) == "b+"
@@ -649,7 +646,7 @@ def test_reduce_concatenations():
 # Multiplication tests
 
 
-def test_mult_multiplication():
+def test_mult_multiplication() -> None:
     assert parse("(a{2,3}){1,1}").reduce() == parse("a{2,3}").reduce()
     assert parse("(a{2,3}){1}").reduce() == parse("a{2,3}").reduce()
     assert parse("(a{2,3})").reduce() == parse("a{2,3}").reduce()
@@ -657,16 +654,16 @@ def test_mult_multiplication():
     assert parse("(a{2,}){2,}").reduce() == parse("a{4,}").reduce()
 
 
-def test_even_star_bug2():
+def test_even_star_bug2() -> None:
     # Defect: (a{2})* should NOT reduce to a*
     assert parse("(a{2})*").reduce() != parse("a*").reduce()
 
 
-def test_two_or_more_qm_bug():
+def test_two_or_more_qm_bug() -> None:
     assert str(parse("(a{2,})?").reduce()) == "(a{2,})?"
 
 
-def test_two_two_bug():
+def test_two_two_bug() -> None:
     assert str(parse("(a{2}){2}").reduce()) == "a{4}"
 
 
@@ -674,7 +671,7 @@ def test_two_two_bug():
 # Test intersection (&)
 
 
-def test_mult_intersection():
+def test_mult_intersection() -> None:
     assert str(parse("a") & parse("a")) == "a"
     assert str(parse("a*") & parse("a")) == "a"
     assert str(parse("a") & parse("a?")) == "a"
@@ -684,7 +681,7 @@ def test_mult_intersection():
     assert str(parse("a{3,}") & parse("a{3,}")) == "a{3,}"
 
 
-def test_parse_regex_intersection():
+def test_parse_regex_intersection() -> None:
     assert str(parse("a*") & parse("b*")) == ""
     assert str(parse("a") & parse("b")) == "[]"
     assert str(parse("\\d") & parse(".")) == "\\d"
@@ -723,7 +720,7 @@ def test_parse_regex_intersection():
     )
 
 
-def test_complexify():
+def test_complexify() -> None:
     # Complexify!
     gen = (parse("[bc]*[ab]*") & parse("[ab]*[bc]*")).strings()
     assert next(gen) == ""
@@ -742,7 +739,7 @@ def test_complexify():
     assert next(gen) == "aaa"
 
 
-def test_silly_reduction():
+def test_silly_reduction() -> None:
     # This one is horrendous and we have to jump through some hoops to get to
     # a sensible result. Probably not a good unit test actually.
     long = (
@@ -763,7 +760,7 @@ def test_silly_reduction():
 # reduce() tests
 
 
-def test_mult_reduction_easy():
+def test_mult_reduction_easy() -> None:
     assert str(parse("a").reduce()) == "a"
     assert str(parse("a").reduce()) == "a"
     assert str(parse("a?").reduce()) == "a?"
@@ -774,14 +771,14 @@ def test_mult_reduction_easy():
     assert str(parse("[]{0,5}").reduce()) == ""
 
 
-def test_conc_reduction_basic():
+def test_conc_reduction_basic() -> None:
     assert str(parse("a").reduce()) == "a"
     assert str(parse("a{3,4}").reduce()) == "a{3,4}"
     assert str(parse("ab").reduce()) == "ab"
     assert str(parse("a[]b").reduce()) == "[]"
 
 
-def test_pattern_reduce_basic():
+def test_pattern_reduce_basic() -> None:
     assert str(parse("ab|cd").reduce()) == "ab|cd"
     assert str(parse("a{2}b{2}").reduce()) == "a{2}b{2}"
     assert str(parse("a{2}").reduce()) == "a{2}"
@@ -789,16 +786,16 @@ def test_pattern_reduce_basic():
     assert str(parse("(((a)))").reduce()) == "a"
 
 
-def test_empty_conc_suppression():
+def test_empty_conc_suppression() -> None:
     assert str(parse("[]0\\d").reduce()) == "[]"
 
 
-def test_nested_pattern_reduction():
+def test_nested_pattern_reduction() -> None:
     # a(d(ab|a*c)) -> ad(ab|a*c)
     assert str(parse("a(d(ab|a*c))").reduce()) == "ad(a*c|ab)"
 
 
-def test_mult_factor_out_qm():
+def test_mult_factor_out_qm() -> None:
     # `Mult` contains a `Pattern` containing an empty `Conc`? Pull the empty
     # part out where it's external
     assert str(parse("a|b*|").reduce()) == "a|b*"
@@ -810,7 +807,7 @@ def test_mult_factor_out_qm():
     assert str(parse("([$%\\^]|){1}").reduce()) == "[$%\\^]?"
 
 
-def test_remove_unnecessary_parens():
+def test_remove_unnecessary_parens() -> None:
     # `Mult` contains a `Pattern` containing a single `Conc` containing a
     # single `Mult`? That can be reduced greatly
     assert str(parse("(a){2}b").reduce()) == "a{2}b"
@@ -819,11 +816,11 @@ def test_remove_unnecessary_parens():
     assert str(parse("(c{1,2}){3,4}").reduce()) == "c{3,8}"
 
 
-def test_obvious_reduction():
+def test_obvious_reduction() -> None:
     assert str(parse("(a|b)*").reduce()) == "[ab]*"
 
 
-def test_mult_squoosh():
+def test_mult_squoosh() -> None:
     # sequence squooshing of mults within a `Conc`
     assert str(parse("[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]").reduce()) == "[0-9A-Fa-f]{3}"
     assert str(parse("[$%\\^]?[$%\\^]").reduce()) == "[$%\\^]{1,2}"
@@ -837,7 +834,7 @@ def test_mult_squoosh():
     )
 
 
-def test_bad_reduction_bug():
+def test_bad_reduction_bug() -> None:
     # DEFECT: "0{2}|1{2}" was erroneously reduced() to "[01]{2}"
     assert parse("0{2}|1{2}").reduce() != parse("[01]{2}")
     assert parse("0|[1-9]|ab").reduce() == parse("\\d|ab")
@@ -846,27 +843,27 @@ def test_bad_reduction_bug():
     # TODO: should do better than this! Merge that 0
 
 
-def test_common_prefix_pattern_reduction():
+def test_common_prefix_pattern_reduction() -> None:
     assert str(parse("a{2}b|a+c").reduce()) == "a(a*c|ab)"
 
 
-def test_epsilon_reduction():
+def test_epsilon_reduction() -> None:
     assert str(parse("|(ab)*|def").reduce()) == "(ab)*|def"
     assert str(parse("|(ab)+|def").reduce()) == "(ab)*|def"
     assert str(parse("|.+").reduce()) == ".*"
     assert str(parse("|a+|b+").reduce()) in {"a+|b*", "a*|b+"}
 
 
-def test_charclass_intersection_2():
+def test_charclass_intersection_2() -> None:
     assert (parse("[A-z]") & parse("[^g]")).reduce() == parse("[A-fh-z]").reduce()
 
 
-def test_reduce_boom():
+def test_reduce_boom() -> None:
     # make sure recursion problem in reduce() has gone away
     assert str(parse("([1-9]|0)").reduce()) == "\\d"
 
 
-def test_new_reduce():
+def test_new_reduce() -> None:
     # The @reduce_after decorator has been removed from many methods since it
     # takes unnecessary time which the user may not wish to spend.
     # This alters the behaviour of several methods and also exposes a new
@@ -876,7 +873,7 @@ def test_new_reduce():
     assert str(parse("a.b()()").reduce()) == "a.b"
 
 
-def test_main_bug():
+def test_main_bug() -> None:
     assert str(parse("a*").reduce()) == "a*"
     assert str(parse("a|a*").reduce()) == "a*"
     assert str(parse("a{1,2}|a{3,4}|bc").reduce()) == "a{1,4}|bc"
@@ -889,19 +886,19 @@ def test_main_bug():
     assert str((parse("a") | parse("a*")).reduce()) == "a*"
 
 
-def test_bug_28_b():
+def test_bug_28_b() -> None:
     # Defect in rxelems.to_fsm()
     assert not parse("(ab*)*").to_fsm().accepts("bb")
 
 
-def test_derive():
+def test_derive() -> None:
     assert str(parse("a+").derive("a")) == "a*"
     assert str(parse("a+|b+").derive("a")) == "a*"
     assert str(parse("abc|ade").derive("a")) == "bc|de"
     assert str(parse("abc|ade").derive("ab")) == "c"
 
 
-def test_bug_36_1():
+def test_bug_36_1() -> None:
     etc1 = parse(".*").to_fsm()
     etc2 = parse("s.*").to_fsm()
     assert etc1.accepts("s")
@@ -910,7 +907,7 @@ def test_bug_36_1():
     assert not etc2.isdisjoint(etc1)
 
 
-def test_bug_36_2():
+def test_bug_36_2() -> None:
     etc1 = parse("/etc/.*").to_fsm()
     etc2 = parse("/etc/something.*").to_fsm()
     assert etc1.accepts("/etc/something")
@@ -919,7 +916,7 @@ def test_bug_36_2():
     assert not etc2.isdisjoint(etc1)
 
 
-def test_isdisjoint():
+def test_isdisjoint() -> None:
     xyzzy = parse("xyz(zy)?")
     xyz = parse("xyz")
     blippy = parse("blippy")
@@ -927,7 +924,7 @@ def test_isdisjoint():
     assert not xyzzy.isdisjoint(xyz)
 
 
-def test_bug_slow():
+def test_bug_slow() -> None:
     # issue #43
     m = Fsm(
         alphabet={"R", "L", "U", "D"},
@@ -987,7 +984,7 @@ def test_bug_slow():
     assert ll == parse("(DLURULLDRD|ULDRDLLURU)L").reduce()
 
 
-def test_bug_48_simpler():
+def test_bug_48_simpler() -> None:
     assert (
         str(
             from_fsm(
@@ -1006,7 +1003,7 @@ def test_bug_48_simpler():
     )
 
 
-def test_bug_48():
+def test_bug_48() -> None:
     S5, S26, S45, S63, S80, S97, S113, S127, S140, S152, S163, S175, S182 = range(13)
     char0, char1, char2, char3, char4, char5, char6, char7, char8 = (
         "_",
@@ -1045,7 +1042,7 @@ def test_bug_48():
     assert str(rex) == "damage_on_mp"
 
 
-def test_pickle():
+def test_pickle() -> None:
     f1 = parse("a{0,4}").to_fsm()
     f2 = parse("a{0,3}").to_fsm()
 


### PR DESCRIPTION
This allows `mypy --strict greenery/{rxelems,{rxelems,conc,mult,pattern}_test}.py` to pass.