### PR TITLE
parse.py + parse_test.py type fixes

### DIFF
--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -5,6 +5,8 @@ __all__ = (
     "NoMatch",
 )
 
+from typing import Tuple, TypeVar
+
 from .bound import INF, Bound
 from .charclass import Charclass, escapes, shorthand
 from .multiplier import Multiplier, symbolic
@@ -14,6 +16,8 @@ from .rxelems import Conc, Mult, Pattern
 # mypy: allow-untyped-defs
 # mypy: allow-incomplete-defs
 
+T_co = TypeVar("T_co", covariant=True)
+
 
 class NoMatch(Exception):
     """
@@ -22,6 +26,9 @@ class NoMatch(Exception):
     """
 
     pass
+
+
+MatchResult = Tuple[T_co, int]
 
 
 def read_until(string: str, i: int, stop_char: str) -> tuple[str, int]:

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -105,14 +105,14 @@ def match_class_interior_1(string, i):
     # Attempt 1: shorthand e.g. "\w"
     for chars, cc_shorthand in Charclass.shorthand.items():
         try:
-            return chars, False, static(string, i, cc_shorthand)
+            return (chars, False), static(string, i, cc_shorthand)
         except NoMatch:
             pass
 
     # Attempt 1B: shorthand e.g. "\W"
     for chars, cc_shorthand in Charclass.negated_shorthand.items():
         try:
-            return chars, True, static(string, i, cc_shorthand)
+            return (chars, True), static(string, i, cc_shorthand)
         except NoMatch:
             pass
 
@@ -130,13 +130,13 @@ def match_class_interior_1(string, i):
             raise NoMatch(f"Range {first!r} to {last!r} not allowed")
 
         chars = frozenset(chr(i) for i in range(firstIndex, lastIndex + 1))
-        return chars, False, k
+        return (chars, False), k
     except NoMatch:
         pass
 
     # Attempt 3: just a character on its own
     char, j = match_internal_char(string, i)
-    return frozenset(char), False, j
+    return (frozenset(char), False), j
 
 
 def match_class_interior(string, i):
@@ -144,7 +144,7 @@ def match_class_interior(string, i):
     try:
         while True:
             # Match an internal character, range, or other charclass predicate.
-            internal, internal_negated, i = match_class_interior_1(string, i)
+            (internal, internal_negated), i = match_class_interior_1(string, i)
             predicates.append(Charclass(internal, negated=internal_negated))
     except NoMatch:
         pass

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -46,7 +46,7 @@ def select_static(string, i, *statics):
     for st in statics:
         j = i + len(st)
         if string[i:j] == st:
-            return j, st
+            return st, j
     raise NoMatch
 
 
@@ -214,7 +214,7 @@ def match_multiplicand(string, i):
     # explicitly non-capturing "(?:...)" syntax. No special significance
     try:
         j = static(string, i, "(?")
-        j, st = select_static(string, j, ":", "P<")
+        st, j = select_static(string, j, ":", "P<")
         if st == "P<":
             j, group_name = read_until(string, j, ">")
         pattern, j = match_pattern(string, j)

--- a/greenery/parse.py
+++ b/greenery/parse.py
@@ -24,7 +24,7 @@ class NoMatch(Exception):
     pass
 
 
-def read_until(string: str, i: int, stop_char: str) -> tuple[int, str]:
+def read_until(string: str, i: int, stop_char: str) -> tuple[str, int]:
     start = i
     while True:
         if i >= len(string):
@@ -32,7 +32,7 @@ def read_until(string: str, i: int, stop_char: str) -> tuple[int, str]:
         if string[i] == stop_char:
             break
         i += 1
-    return i + 1, string[start:i]
+    return string[start:i], i + 1
 
 
 def static(string, i, static):
@@ -216,7 +216,7 @@ def match_multiplicand(string, i):
         j = static(string, i, "(?")
         st, j = select_static(string, j, ":", "P<")
         if st == "P<":
-            j, group_name = read_until(string, j, ">")
+            group_name, j = read_until(string, j, ">")
         pattern, j = match_pattern(string, j)
         j = static(string, j, ")")
         return pattern, j

--- a/greenery/parse_test.py
+++ b/greenery/parse_test.py
@@ -10,14 +10,11 @@ from .multiplier import ONE, PLUS, STAR, Multiplier
 from .parse import NoMatch, match_charclass, match_mult, parse
 from .rxelems import Conc, Mult, Pattern
 
-# mypy: allow-untyped-calls
-# mypy: allow-untyped-defs
-
 if __name__ == "__main__":
     raise Exception("Test files can't be run directly. Use `python -m pytest greenery`")
 
 
-def test_charclass_matching():
+def test_charclass_matching() -> None:
     assert match_charclass("a", 0) == (Charclass("a"), 1)
     assert match_charclass("aa", 1) == (Charclass("a"), 2)
     assert match_charclass("a$", 1) == (Charclass("$"), 2)
@@ -32,7 +29,7 @@ def test_charclass_matching():
     assert match_charclass("[\\d]", 0) == (DIGIT, 4)
 
 
-def test_negatives_inside_charclasses():
+def test_negatives_inside_charclasses() -> None:
     assert match_charclass("[\\D]", 0) == (~DIGIT, 4)
     assert match_charclass("[a\\D]", 0) == (~DIGIT, 5)
     assert match_charclass("[a1\\D]", 0) == (~Charclass("023456789"), 6)
@@ -49,7 +46,7 @@ def test_negatives_inside_charclasses():
     assert match_charclass("[\\S \\D]", 0) == (DOT, 7)
 
 
-def test_negated_negatives_inside_charclasses():
+def test_negated_negatives_inside_charclasses() -> None:
     assert match_charclass("[^\\D]", 0) == (DIGIT, 5)
     assert match_charclass("[^a\\D]", 0) == (DIGIT, 6)
     assert match_charclass("[^a1\\D]", 0) == (Charclass("023456789"), 7)
@@ -66,7 +63,7 @@ def test_negated_negatives_inside_charclasses():
     assert match_charclass("[^\\S \\D]", 0) == (NULLCHARCLASS, 8)
 
 
-def test_mult_matching():
+def test_mult_matching() -> None:
     assert match_mult("abcde[^fg]*", 5) == (Mult(~Charclass("fg"), STAR), 11)
     assert match_mult("abcde[^fg]*h{5}[a-z]+", 11) == (
         Mult(Charclass("h"), Multiplier(Bound(5), Bound(5))),
@@ -82,14 +79,14 @@ def test_mult_matching():
     )
 
 
-def test_charclass_ranges():
+def test_charclass_ranges() -> None:
     # Should accept arbitrary ranges of characters in charclasses. No longer
     # limited to alphanumerics. (User beware...)
     assert parse("[z{|}~]") == parse("[z-~]")
     assert parse("[\\w:;<=>?@\\[\\\\\\]\\^`]") == parse("[0-z]")
 
 
-def test_hex_escapes():
+def test_hex_escapes() -> None:
     # Should be able to parse e.g. "\\x40"
     assert parse("\\x00") == parse("\x00")
     assert parse("\\x40") == parse("@")
@@ -97,7 +94,7 @@ def test_hex_escapes():
     assert parse("[\\x41-\\x5a]") == parse("[A-Z]")
 
 
-def test_w_d_s():
+def test_w_d_s() -> None:
     # Allow "\w", "\d" and "\s" in charclasses
     assert parse("\\w") == parse("[0-9A-Z_a-z]")
     assert parse("[\\w~]") == parse("[0-9A-Z_a-z~]")
@@ -105,7 +102,7 @@ def test_w_d_s():
     assert parse("[\\s]") == parse("[\t\n\r\f\v ]")
 
 
-def test_mult_parsing():
+def test_mult_parsing() -> None:
     assert parse("[a-g]+") == Pattern(Conc(Mult(Charclass("abcdefg"), PLUS)))
     assert parse("[a-g0-8$%]+") == Pattern(
         Conc(Mult(Charclass("abcdefg012345678$%"), PLUS))
@@ -115,7 +112,7 @@ def test_mult_parsing():
     )
 
 
-def test_conc_parsing():
+def test_conc_parsing() -> None:
     assert parse("abcde[^fg]*h{5}[a-z]+") == Pattern(
         Conc(
             Mult(Charclass("a"), ONE),
@@ -155,7 +152,7 @@ def test_conc_parsing():
     )
 
 
-def test_pattern_parsing():
+def test_pattern_parsing() -> None:
     assert parse("abc|def(ghi|jkl)") == Pattern(
         Conc(
             Mult(Charclass("a"), ONE),

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -37,7 +37,7 @@ class Conc:
 
     mults: tuple[Mult, ...]
 
-    def __init__(self, *mults):
+    def __init__(self, /, *mults: Mult):
         object.__setattr__(self, "mults", tuple(mults))
 
     def __eq__(self, other):
@@ -406,7 +406,7 @@ class Pattern:
 
     concs: frozenset[Conc]
 
-    def __init__(self, *concs):
+    def __init__(self, /, *concs: Conc):
         object.__setattr__(self, "concs", frozenset(concs))
 
     def __eq__(self, other):


### PR DESCRIPTION
This makes the result types consistent in matcher helpers in `parse.py`, defines a generic `MatchResult[…]` type, and annotates the functions there.

This is sufficient to pass `mypy --strict greenery/parse{,_test}.py`.

One change was required in `rxelems`, to avoid `untyped-call` errors due to missing annotations on the `Conc` and `Pattern` constructors: that change is also included effectively in #89 and should merge cleanly.