### PR TITLE
Multiplier: allow serializing `{0}`

### DIFF
--- a/greenery/multiplier.py
+++ b/greenery/multiplier.py
@@ -58,9 +58,6 @@ class Multiplier:
         return f"Multiplier({self.min!r}, {self.max!r})"
 
     def __str__(self, /) -> str:
-        if self.max == Bound(0):
-            raise Exception(f"Can't serialise a multiplier with bound {self.max!r}")
-
         try:
             return symbolic[self]
         except LookupError:

--- a/greenery/multiplier.py
+++ b/greenery/multiplier.py
@@ -60,8 +60,12 @@ class Multiplier:
     def __str__(self, /) -> str:
         if self.max == Bound(0):
             raise Exception(f"Can't serialise a multiplier with bound {self.max!r}")
-        if self in symbolic.keys():
+
+        try:
             return symbolic[self]
+        except LookupError:
+            pass
+
         if self.min == self.max:
             return "{" + str(self.min) + "}"
         return "{" + str(self.min) + "," + str(self.max) + "}"

--- a/greenery/multiplier_test.py
+++ b/greenery/multiplier_test.py
@@ -8,6 +8,9 @@ from .multiplier import ONE, PLUS, QM, STAR, ZERO, Multiplier
 
 def test_multiplier_str() -> None:
     assert str(Multiplier(Bound(2), INF)) == "{2,}"
+    assert str(Multiplier(Bound(0), Bound(0))) == "{0}"
+    assert str(Multiplier(Bound(2), Bound(2))) == "{2}"
+    assert str(Multiplier(Bound(2), Bound(5))) == "{2,5}"
 
 
 def test_bound_qm() -> None:


### PR DESCRIPTION
There should no restriction against the ZERO interval `{0}`:

https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_04
> ```
> Interval expression of the format "{m}", "{m,}", or "{m,n}", together
> with that interval expression it shall match what repeated consecutive
> occurrences of the ERE would match. The values of m and n are decimal
> integers in the range 0 <= m<= n<= {RE_DUP_MAX}, where m specifies the
> exact or minimum number of occurrences and n specifies the maximum
> number of occurrences. The expression "{m}" matches exactly m
> occurrences of the preceding ERE, "{m,}" matches at least m
> occurrences, and "{m,n}" matches any number of occurrences between m
> and n, inclusive.
> ```