### PR TITLE
fsm: Adding "CharClass" to FSM

### DIFF
--- a/greenery/charclass.py
+++ b/greenery/charclass.py
@@ -17,7 +17,7 @@ __all__ = (
 from dataclasses import dataclass
 from typing import ClassVar, Iterable, Mapping
 
-from .fsm import ANYTHING_ELSE, AnythingElse, Fsm
+from .fsm import ANYTHING_ELSE, AnythingElse, Fsm, alpha_type, state_type
 
 
 @dataclass(frozen=True, init=False)
@@ -178,7 +178,7 @@ class Charclass:
     ) -> Fsm:
         alphabet = self.alphabet() if alphabet is None else frozenset(alphabet)
 
-        map: dict[int | str | None, dict[str | AnythingElse, int | str | None]]
+        map: dict[state_type, dict[alpha_type, state_type]]
 
         # 0 is initial, 1 is final
 

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pickle
 from collections import deque
 from copy import copy
-from typing import Iterable
+from typing import Iterator
 
 import pytest
 
@@ -14,7 +14,7 @@ FixtureA = Fsm
 FixtureB = Fsm
 
 
-def strings(fsm: Fsm) -> Iterable[list[alpha_type]]:
+def strings(fsm: Fsm) -> Iterator[list[alpha_type]]:
     """
     Generates a list of all strings `fsm` accepts.
     Only intended to test if the Fsm

--- a/greenery/fsm_test.py
+++ b/greenery/fsm_test.py
@@ -3,11 +3,20 @@ from __future__ import annotations
 import pickle
 from collections import deque
 from copy import copy
-from typing import Iterator, Literal, Union, FrozenSet
+from typing import FrozenSet, Iterator, Literal, Union, cast
 
 import pytest
 
-from .fsm import ANYTHING_ELSE, AnythingElse, Fsm, alpha_type, epsilon, null, state_type
+from .fsm import (
+    ANYTHING_ELSE,
+    AnythingElse,
+    Fsm,
+    alpha_type,
+    alphabet_sort_key,
+    epsilon,
+    null,
+    state_type,
+)
 
 FixtureA = Fsm
 
@@ -34,7 +43,7 @@ def strings(fsm: Fsm) -> Iterator[list[alpha_type]]:
     while strings:
         current_string, current_state = strings.popleft()
         if current_state in fsm.map:
-            for symbol in sorted(fsm.map[current_state], key=lambda a: min(a) if isinstance(a, frozenset) else a):
+            for symbol in sorted(fsm.map[current_state], key=alphabet_sort_key):
                 next_state = fsm.map[current_state][symbol]
                 next_string = current_string + [symbol]
                 if next_state in livestates:
@@ -83,7 +92,7 @@ def test_builtins() -> None:
 
 @pytest.fixture(params=["str", "frozenset", "mixed"])
 def mode(request: pytest.FixtureRequest) -> str:
-    return request.param
+    return cast(str, request.param)
 
 
 @pytest.fixture
@@ -133,7 +142,7 @@ def test_a(a: FixtureA) -> None:
 
 
 @pytest.fixture
-def b(a_sym, b_sym) -> FixtureB:
+def b(a_sym: Symbol, b_sym: Symbol) -> FixtureB:
     b = Fsm(
         alphabet={a_sym, b_sym},
         states={0, 1, "ob"},
@@ -668,7 +677,9 @@ def test_dead_default() -> None:
     assert next(strings(blockquote)) == ["/", "*", "*", "/"]
 
 
-def test_new_set_methods(a: FixtureA, b: FixtureB, a_sym: Symbol, b_sym: Symbol) -> None:
+def test_new_set_methods(
+    a: FixtureA, b: FixtureB, a_sym: Symbol, b_sym: Symbol
+) -> None:
     # A whole bunch of new methods were added to the FSM module to enable FSMs
     # to function exactly as if they were sets of strings (symbol lists), see:
     # https://docs.python.org/3/library/stdtypes.html#set-types-set-frozenset

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -329,9 +329,14 @@ def from_fsm(f: Fsm) -> Pattern:
             b = f.map[a][symbol]
             if symbol is ANYTHING_ELSE:
                 charclass = ~Charclass(
-                    frozenset(s for s in f.alphabet if s is not ANYTHING_ELSE)
+                    frozenset(
+                        s  # type: ignore[misc]
+                        for s in f.alphabet
+                        if s is not ANYTHING_ELSE
+                    )
                 )
             else:
+                assert isinstance(symbol, str)
                 charclass = Charclass(frozenset((symbol,)))
 
             brz[a][b] = Pattern(*brz[a][b].concs, Conc(Mult(charclass, ONE))).reduce()
@@ -788,6 +793,7 @@ class Pattern:
                         if otherchar is None:
                             raise TypeError("Please choose an `otherchar`")
                         symbol = otherchar
+                    assert isinstance(symbol, str)
                     next_string = current_string + symbol
                     if next_state in livestates:
                         if next_state in fsm.finals:

--- a/greenery/rxelems.py
+++ b/greenery/rxelems.py
@@ -164,6 +164,7 @@ class Conc:
 
     def alphabet(self, /) -> frozenset[str | AnythingElse]:
         components = self.mults
+        # TODO: Alphabet union
         return frozenset().union(*(c.alphabet() for c in components)) | {ANYTHING_ELSE}
 
     def empty(self, /) -> bool:
@@ -408,6 +409,7 @@ class Pattern:
 
     def alphabet(self, /) -> frozenset[str | AnythingElse]:
         components = self.concs
+        # TODO: Alphabet union
         return frozenset().union(*(c.alphabet() for c in components)) | {ANYTHING_ELSE}
 
     def empty(self, /) -> bool:
@@ -415,6 +417,7 @@ class Pattern:
 
     def intersection(self, other: Pattern, /) -> Pattern:
         # A deceptively simple method for an astoundingly difficult operation
+        # TODO: Alphabet union
         alphabet = self.alphabet() | other.alphabet()
 
         # Which means that we can build finite state machines sharing that
@@ -430,6 +433,7 @@ class Pattern:
         Return a regular expression which matches any string which `self`
         matches but none of the strings which `other` matches.
         """
+        # TODO: Alphabet union
         alphabet = frozenset().union(*(elem.alphabet() for elem in elems))
         return from_fsm(Fsm.difference(*(elem.to_fsm(alphabet) for elem in elems)))
 
@@ -577,6 +581,7 @@ class Pattern:
         Return a regular expression matching only the strings recognised by
         `self` or `other` but not both.
         """
+        # TODO: Alphabet union
         alphabet = frozenset().union(*(elem.alphabet() for elem in elems))
         return from_fsm(
             Fsm.symmetric_difference(*(elem.to_fsm(alphabet) for elem in elems))
@@ -646,7 +651,9 @@ class Pattern:
         Note that in the general case this is actually quite an intensive
         calculation, but far from unsolvable, as we demonstrate here:
         """
-        return self.to_fsm().equivalent(other.to_fsm())
+        # TODO: Alphabet union
+        alphabet = self.alphabet() | other.alphabet()
+        return self.to_fsm(alphabet).equivalent(other.to_fsm(alphabet))
 
     def times(self, multiplier: Multiplier, /) -> Pattern:
         """
@@ -677,9 +684,12 @@ class Pattern:
         Treat `self` and `other` as sets of strings and see if they are
         disjoint
         """
-        return self.to_fsm().isdisjoint(other.to_fsm())
+        # TODO: Alphabet union
+        alphabet = self.alphabet() | other.alphabet()
+        return self.to_fsm(alphabet).isdisjoint(other.to_fsm(alphabet))
 
     def matches(self, string: str, /) -> bool:
+        # TODO: accepts call with string
         return self.to_fsm().accepts(string)
 
     def __contains__(self, string: str, /) -> bool:

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -9,7 +9,7 @@ import pytest
 from .charclass import DIGIT, WORDCHAR
 from .fsm import ANYTHING_ELSE, Fsm
 from .parse import parse
-from .rxelems import from_fsm
+from .rxelems import from_fsm, alphabet_union
 
 if __name__ == "__main__":
     raise Exception("Test files can't be run directly. Use `python -m pytest greenery`")
@@ -46,6 +46,15 @@ def test_alphabet() -> None:
     # `.alphabet()` should include `ANYTHING_ELSE`
     assert parse("").alphabet() == {ANYTHING_ELSE}
 
+def test_alphabet_union() -> None:
+    a = frozenset((*"abc", ANYTHING_ELSE))
+    b = frozenset((*"cde", ANYTHING_ELSE))
+    assert alphabet_union(a, b) == frozenset((*"abcde", ANYTHING_ELSE))
+    c = frozenset({frozenset("abc"), frozenset("de"), ANYTHING_ELSE})
+    d = frozenset({frozenset("ab"), frozenset("cd"), frozenset("ef"), ANYTHING_ELSE})
+    assert alphabet_union(c, d) == frozenset({
+        frozenset("ab"), "c", "d", "e", "f", ANYTHING_ELSE
+    })
 
 def test_pattern_fsm() -> None:
     # "a[^a]"
@@ -471,6 +480,7 @@ def test_base_N() -> None:
         a = b
 
 
+@pytest.mark.xfail(reason="Temporarily increasing FSM alphabet restrictions making this test unusable")
 def test_bad_alphabet() -> None:
     # You can use anything you like in your FSM alphabet, but if you try to
     # convert it to an `rxelems` object then the only acceptable symbols are

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -256,7 +256,7 @@ def test_forin() -> None:
     assert [s for s in parse("abc|def(ghi|jkl)")] == ["abc", "defghi", "defjkl"]
 
 
-def test_brzozowski_reverse():
+def test_brzozowski_reverse() -> None:
     # A continuation of the test of the same name in fsm_test.py
     brzozowski = parse("(a|b)*a(a|b)")
     gen = brzozowski.strings()

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -920,24 +920,6 @@ def test_derive() -> None:
     assert str(parse("abc|ade").derive("ab")) == "c"
 
 
-def test_bug_36_1() -> None:
-    etc1 = parse(".*").to_fsm()
-    etc2 = parse("s.*").to_fsm()
-    assert etc1.accepts("s")
-    assert etc2.accepts("s")
-    assert not etc1.isdisjoint(etc2)
-    assert not etc2.isdisjoint(etc1)
-
-
-def test_bug_36_2() -> None:
-    etc1 = parse("/etc/.*").to_fsm()
-    etc2 = parse("/etc/something.*").to_fsm()
-    assert etc1.accepts("/etc/something")
-    assert etc2.accepts("/etc/something")
-    assert not etc1.isdisjoint(etc2)
-    assert not etc2.isdisjoint(etc1)
-
-
 def test_isdisjoint() -> None:
     xyzzy = parse("xyz(zy)?")
     xyz = parse("xyz")

--- a/greenery/rxelems_test.py
+++ b/greenery/rxelems_test.py
@@ -256,6 +256,28 @@ def test_forin() -> None:
     assert [s for s in parse("abc|def(ghi|jkl)")] == ["abc", "defghi", "defjkl"]
 
 
+def test_brzozowski_reverse():
+    # A continuation of the test of the same name in fsm_test.py
+    brzozowski = parse("(a|b)*a(a|b)")
+    gen = brzozowski.strings()
+    assert next(gen) == "aa"
+    assert next(gen) == "ab"
+    assert next(gen) == "aaa"
+    assert next(gen) == "aab"
+    assert next(gen) == "baa"
+    assert next(gen) == "bab"
+    assert next(gen) == "aaaa"
+
+    b2 = brzozowski.reversed()
+    gen = b2.strings()
+    assert next(gen) == "aa"
+    assert next(gen) == "ba"
+    assert next(gen) == "aaa"
+    assert next(gen) == "aab"
+    assert next(gen) == "baa"
+    assert next(gen) == "bab"
+    assert next(gen) == "aaaa"
+
 ###############################################################################
 # Test cardinality() and len()
 
@@ -369,11 +391,11 @@ def test_even_star_bug1() -> None:
     assert elesscomplex.accepts("a")
     assert not elesscomplex.accepts("aa")
     assert elesscomplex.accepts("aaa")
-    gen = elesscomplex.strings()
-    assert next(gen) == ["a"]
-    assert next(gen) == ["a", "a", "a"]
-    assert next(gen) == ["a", "a", "a", "a", "a"]
-    assert next(gen) == ["a", "a", "a", "a", "a", "a", "a"]
+    gen = elesscomplex_pat.strings()
+    assert next(gen) == "a"
+    assert next(gen) == "aaa"
+    assert next(gen) == "aaaaa"
+    assert next(gen) == "aaaaaaa"
 
 
 def test_binary_3() -> None:


### PR DESCRIPTION
Second attempt at fixing #81, after #82.

For the moment I only did the small task @qntm directly asked me to do, moving strings and cardinality functions from `Fsm` to `Pattern`. This was a bit awkward as can probably be seen from the resulting changes. The tests in `fsm_test.py` are using `.strings()` (and to a lesser extend `len()`) not just to test whether or not those specific functions work, but also to test the other functions (like `concatenation`), so I decided to copy over a version of `strings` code into the test file for those use cases.

I did try to turn `Fsm` into a generic class over `alpha_type`, however because of the reliance on `AnythingElse` and `sorted`, mypy has a lot of complains. Maybe @rwe has an idea on how to correctly express that? But that is pretty tangential to the primary point of this project.

I will see if I can implement a basic version of `Charclass` in the next few days. I do have a lot of code for that lying around.